### PR TITLE
Enable Flutter web login against backend

### DIFF
--- a/pymerp/app_flutter/Makefile
+++ b/pymerp/app_flutter/Makefile
@@ -14,10 +14,10 @@ test:
 	flutter test
 
 run-web:
-	flutter run -d chrome --dart-define=BASE_URL=http://localhost:8080 --dart-define=COMPANY_ID=dev-company
+	flutter run -d chrome --dart-define=BASE_URL=http://localhost:8081 --dart-define=COMPANY_ID=dev-company
 
 run-win:
-	flutter run -d windows --dart-define=BASE_URL=http://localhost:8080 --dart-define=COMPANY_ID=dev-company
+	flutter run -d windows --dart-define=BASE_URL=http://localhost:8081 --dart-define=COMPANY_ID=dev-company
 
 run-android:
-	flutter run -d android --dart-define=BASE_URL=http://10.0.2.2:8080 --dart-define=COMPANY_ID=dev-company
+	flutter run -d android --dart-define=BASE_URL=http://10.0.2.2:8081 --dart-define=COMPANY_ID=dev-company

--- a/pymerp/app_flutter/README.md
+++ b/pymerp/app_flutter/README.md
@@ -4,7 +4,7 @@
 - Flutter 3.22+
 - Android SDK, Chrome, Windows Desktop
 
-## Setup rápido
+* BASE_URL (ej: http://localhost:8081)
 `ash
 cd app_flutter
 make bootstrap
@@ -27,9 +27,9 @@ make run-web
 
 ### Funcionalidades clave
 
-* Clientes con paginación/infinite scroll y refresco manual.
-* Formularios con lat/lng opcionales (double?), validaciones de rango y botón **“Usar ubicación actual”**.
-* Serialización JSON omitiendo lat/lng cuando son 
+* Clientes con paginaciÃ³n/infinite scroll y refresco manual.
+* Formularios con lat/lng opcionales (double?), validaciones de rango y botÃ³n **â€œUsar ubicaciÃ³n actualâ€**.
+* SerializaciÃ³n JSON omitiendo lat/lng cuando son 
 ull.
 * Cabeceras Authorization y X-Company-Id en todas las peticiones (multitenencia).
 
@@ -38,9 +38,9 @@ ull.
 `ash
 make test
 `
-Incluye pruebas de serialización y controladores de paginación; se añadió un widget test para validar la forma de clientes.
+Incluye pruebas de serializaciÃ³n y controladores de paginaciÃ³n; se aÃ±adiÃ³ un widget test para validar la forma de clientes.
 
 ### Notas
 
-* Para geolocalización en Web/Android/Windows se solicita permiso en tiempo de ejecución; si se deniega, se informa mediante SnackBar.
-* Falta implementar edición de clientes, sincronización offline y manejo avanzado de errores.
+* Para geolocalizaciÃ³n en Web/Android/Windows se solicita permiso en tiempo de ejecuciÃ³n; si se deniega, se informa mediante SnackBar.
+* Falta implementar ediciÃ³n de clientes, sincronizaciÃ³n offline y manejo avanzado de errores.

--- a/pymerp/app_flutter/lib/core/env.dart
+++ b/pymerp/app_flutter/lib/core/env.dart
@@ -1,5 +1,5 @@
 class Env {
-  static const String baseUrl = String.fromEnvironment('BASE_URL', defaultValue: 'http://localhost:8080');
+  static const String baseUrl = String.fromEnvironment('BASE_URL', defaultValue: 'http://localhost:8081');
   static const String companyId = String.fromEnvironment('COMPANY_ID', defaultValue: 'dev-company');
   static const bool useHttps = bool.fromEnvironment('USE_HTTPS', defaultValue: false);
 }

--- a/pymerp/backend/src/main/java/com/datakomerz/pymes/config/AppProperties.java
+++ b/pymerp/backend/src/main/java/com/datakomerz/pymes/config/AppProperties.java
@@ -27,6 +27,7 @@ public class AppProperties {
 
   public static class Cors {
     private List<String> allowedOrigins = new ArrayList<>();
+    private List<String> allowedOriginPatterns = new ArrayList<>();
 
     public List<String> getAllowedOrigins() {
       return allowedOrigins;
@@ -34,6 +35,14 @@ public class AppProperties {
 
     public void setAllowedOrigins(List<String> allowedOrigins) {
       this.allowedOrigins = allowedOrigins;
+    }
+
+    public List<String> getAllowedOriginPatterns() {
+      return allowedOriginPatterns;
+    }
+
+    public void setAllowedOriginPatterns(List<String> allowedOriginPatterns) {
+      this.allowedOriginPatterns = allowedOriginPatterns;
     }
   }
 

--- a/pymerp/backend/src/main/java/com/datakomerz/pymes/config/SecurityConfig.java
+++ b/pymerp/backend/src/main/java/com/datakomerz/pymes/config/SecurityConfig.java
@@ -95,11 +95,20 @@ public class SecurityConfig {
   @Bean
   CorsConfigurationSource corsConfigurationSource() {
     CorsConfiguration cfg = new CorsConfiguration();
-    var origins = appProperties.getCors().getAllowedOrigins();
-    if (origins == null || origins.isEmpty()) {
+    var cors = appProperties.getCors();
+    var origins = cors.getAllowedOrigins();
+    var originPatterns = cors.getAllowedOriginPatterns();
+    boolean hasOrigins = origins != null && !origins.isEmpty();
+    boolean hasPatterns = originPatterns != null && !originPatterns.isEmpty();
+    if (!hasOrigins && !hasPatterns) {
       cfg.setAllowedOriginPatterns(List.of("*"));
     } else {
-      cfg.setAllowedOrigins(origins);
+      if (hasOrigins) {
+        cfg.setAllowedOrigins(origins);
+      }
+      if (hasPatterns) {
+        cfg.setAllowedOriginPatterns(originPatterns);
+      }
     }
     cfg.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
     cfg.setAllowedHeaders(List.of("Authorization", "Content-Type", "X-Requested-With", "X-Company-Id"));

--- a/pymerp/backend/src/main/resources/application-dev.properties
+++ b/pymerp/backend/src/main/resources/application-dev.properties
@@ -23,6 +23,9 @@ management.endpoint.health.show-details=always
 
 app.cors.allowed-origins[0]=http://localhost:5173
 app.cors.allowed-origins[1]=http://localhost:5174
+app.cors.allowed-origin-patterns[0]=http://localhost:*
+app.cors.allowed-origin-patterns[1]=http://127.0.0.1:*
+app.cors.allowed-origin-patterns[2]=http://0.0.0.0:*
 app.security.jwt.secret=dev-secret-change-me-please-32chars-min
 app.security.jwt.expiration-seconds=86400
 app.security.jwt.refresh-expiration-seconds=2592000

--- a/pymerp/backend/src/main/resources/application.yml
+++ b/pymerp/backend/src/main/resources/application.yml
@@ -38,6 +38,10 @@ app:
     allowed-origins:
       - http://localhost:5173
       - http://localhost:5174
+    allowed-origin-patterns:
+      - http://localhost:*
+      - http://127.0.0.1:*
+      - http://0.0.0.0:*
   security:
     jwt:
       secret: change-this-dev-secret-at-least-32-chars-long


### PR DESCRIPTION
## Summary
- add support for configurable CORS origin patterns and allow localhost wildcards for dev profiles so Flutter web can call the API
- align Flutter defaults (env, make targets, docs) with the backend dev port exposed by docker-compose

## Testing
- ./gradlew test


------
https://chatgpt.com/codex/tasks/task_b_68d562e437688330818e1b3794a3db11