### PR TITLE
Enable in-memory dev database and seed admin

### DIFF
--- a/pymerp/backend/build.gradle
+++ b/pymerp/backend/build.gradle
@@ -32,6 +32,7 @@ dependencies {
   implementation 'org.flywaydb:flyway-core'
   implementation 'org.flywaydb:flyway-database-postgresql'
   runtimeOnly 'org.postgresql:postgresql'
+  runtimeOnly "com.h2database:h2"
   
   // OpenAPI (Swagger UI)
   implementation "org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0"

--- a/pymerp/backend/src/main/java/com/datakomerz/pymes/auth/AuthDataInitializer.java
+++ b/pymerp/backend/src/main/java/com/datakomerz/pymes/auth/AuthDataInitializer.java
@@ -1,15 +1,19 @@
 package com.datakomerz.pymes.auth;
 
+import com.datakomerz.pymes.company.Company;
 import com.datakomerz.pymes.config.AppProperties;
 import com.datakomerz.pymes.company.CompanyRepository;
-import java.util.Optional;
 import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
 
 @Component
 public class AuthDataInitializer implements CommandLineRunner {
+
+  private static final Logger log = LoggerFactory.getLogger(AuthDataInitializer.class);
 
   private final UserAccountRepository userAccountRepository;
   private final CompanyRepository companyRepository;
@@ -29,22 +33,33 @@ public class AuthDataInitializer implements CommandLineRunner {
   @Override
   public void run(String... args) {
     String adminEmail = "admin@dev.local";
-    userAccountRepository.findByEmailIgnoreCase(adminEmail)
-      .orElseGet(() -> {
-        UUID companyId = resolveDefaultCompany();
-        if (companyId == null) {
-          return null;
-        }
-        UserAccount admin = new UserAccount();
-        admin.setCompanyId(companyId);
-        admin.setEmail(adminEmail);
-        admin.setName("Dev Admin");
-        admin.setRole("admin");
-        admin.setStatus("active");
-        admin.setRoles("ROLE_ADMIN");
-        admin.setPasswordHash(passwordEncoder.encode("Admin1234"));
-        return userAccountRepository.save(admin);
-      });
+    if (userAccountRepository.findByEmailIgnoreCase(adminEmail).isPresent()) {
+      return;
+    }
+
+    UUID companyId = resolveDefaultCompany();
+    if (companyId == null) {
+      log.warn("Skipping default admin bootstrap because no company could be resolved");
+      return;
+    }
+
+    companyRepository.findById(companyId).orElseGet(() -> {
+      Company company = new Company();
+      company.setId(companyId);
+      company.setName("Dev Company");
+      company.setRut("76.000.000-0");
+      return companyRepository.save(company);
+    });
+
+    UserAccount admin = new UserAccount();
+    admin.setCompanyId(companyId);
+    admin.setEmail(adminEmail);
+    admin.setName("Dev Admin");
+    admin.setRole("admin");
+    admin.setStatus("active");
+    admin.setRoles("ROLE_ADMIN");
+    admin.setPasswordHash(passwordEncoder.encode("Admin1234"));
+    userAccountRepository.save(admin);
   }
 
   private UUID resolveDefaultCompany() {

--- a/pymerp/backend/src/main/resources/application-dev.yml
+++ b/pymerp/backend/src/main/resources/application-dev.yml
@@ -1,4 +1,24 @@
 spring:
+  datasource:
+    url: "jdbc:h2:mem:pymes;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;DEFAULT_NULL_ORDERING=HIGH"
+    driver-class-name: org.h2.Driver
+    username: sa
+    password: ""
+    hikari:
+      jdbc-url: "jdbc:h2:mem:pymes;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;DEFAULT_NULL_ORDERING=HIGH"
+  jpa:
+    generate-ddl: true
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.H2Dialect
+  flyway:
+    enabled: false
+  h2:
+    console:
+      enabled: true
+      path: /h2-console
   security:
     oauth2:
       resourceserver:


### PR DESCRIPTION
## Summary
- add H2 as a runtime dependency and configure the dev profile to use an in-memory database instead of Postgres
- disable Flyway in dev and create the default company/admin records programmatically so bootRun works without external services

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_b_68d6db864fc0833096edd0b4ab0f34b7