### PR TITLE
Disable Redis health checks for local development profile

### DIFF
--- a/pymerp/backend/src/main/resources/application-dev.properties
+++ b/pymerp/backend/src/main/resources/application-dev.properties
@@ -17,6 +17,10 @@ spring.flyway.password=${POSTGRES_MIGRATION_PASSWORD:${POSTGRES_PASSWORD:pymes}}
 spring.redis.host=${REDIS_HOST:localhost}
 spring.redis.port=${REDIS_PORT:6379}
 
+# Disable the Redis health indicator in local development so the health endpoint
+# reports UP even when no Redis instance is running.
+management.health.redis.enabled=false
+
 management.endpoints.web.base-path=/actuator
 management.endpoints.web.exposure.include=health,info,metrics
 management.endpoint.health.show-details=always

--- a/pymerp/backend/src/main/resources/application-dev.yml
+++ b/pymerp/backend/src/main/resources/application-dev.yml
@@ -33,3 +33,6 @@ management:
   endpoint:
     health:
       show-details: never
+  health:
+    redis:
+      enabled: false


### PR DESCRIPTION
## Summary
- disable the Redis health indicator in the development configuration so the health endpoint remains UP without Redis

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_b_68d70174a42c8330bc326ab2f5989ca9