### PR TITLE
feat(ui): allow offline dev login fallback

### DIFF
--- a/pymerp/ui/src/pages/LoginPage.tsx
+++ b/pymerp/ui/src/pages/LoginPage.tsx
@@ -1,4 +1,5 @@
-import { FormEvent, useEffect, useState } from "react";
+import axios from "axios";
+import { FormEvent, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { useAuth } from "../context/AuthContext";
 
@@ -16,8 +17,12 @@ export default function LoginPage() {
     try {
       await login({ email: form.email.trim(), password: form.password });
       navigate("/");
-    } catch (err: any) {
-      const detail = err?.response?.data?.detail ?? err?.message ?? "Credenciales inv�lidas";
+    } catch (err: unknown) {
+      if (axios.isAxiosError(err) && !err.response) {
+        setError("No se pudo conectar con el servidor. Verifica tu conexión e inténtalo nuevamente.");
+        return;
+      }
+      const detail = (err as any)?.response?.data?.detail ?? (err as Error)?.message ?? "Credenciales inválidas";
       setError(detail);
     } finally {
       setLoading(false);
@@ -31,7 +36,7 @@ export default function LoginPage() {
   return (
     <div className="auth-container">
       <form className="auth-card" onSubmit={onSubmit}>
-        <h1>Iniciar sesi�n</h1>
+        <h1>Iniciar sesión</h1>
         <p className="muted">Usa las credenciales de tu cuenta para acceder al panel.</p>
 
         <label className="auth-label">
@@ -47,7 +52,7 @@ export default function LoginPage() {
         </label>
 
         <label className="auth-label">
-          <span>Contrase�a</span>
+          <span>Contraseña</span>
           <input
             className="input"
             type="password"
@@ -65,7 +70,7 @@ export default function LoginPage() {
         </button>
 
         <p className="muted small">
-          �Problemas? Contacta al administrador de tu compa��a.
+          ¿Problemas? Contacta al administrador de tu compañía.
         </p>
         <p className="muted small">
           Dev quicklinks: <Link to="/" className="btn-link">Dashboard</Link>


### PR DESCRIPTION
## Summary
- add an offline development fallback session when the API is unreachable during login or token refresh
- improve login form error handling with a clearer network connectivity message for users

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d706f7771c8330b0b8637bbc74959a