### PR TITLE
Remove login captcha requirement

### DIFF
--- a/pymerp/backend/src/main/java/com/datakomerz/pymes/auth/application/LoginUseCase.java
+++ b/pymerp/backend/src/main/java/com/datakomerz/pymes/auth/application/LoginUseCase.java
@@ -3,7 +3,6 @@ package com.datakomerz.pymes.auth.application;
 import com.datakomerz.pymes.auth.RefreshTokenService;
 import com.datakomerz.pymes.auth.dto.AuthRequest;
 import com.datakomerz.pymes.auth.dto.AuthResponse;
-import com.datakomerz.pymes.common.captcha.SimpleCaptchaValidationService;
 import com.datakomerz.pymes.config.AppProperties;
 import com.datakomerz.pymes.security.AppUserDetails;
 import com.datakomerz.pymes.security.jwt.JwtService;
@@ -20,24 +19,20 @@ public class LoginUseCase {
   private final AppProperties appProperties;
   private final RefreshTokenService refreshTokenService;
   private final AuthResponseFactory authResponseFactory;
-  private final SimpleCaptchaValidationService captchaValidationService;
 
   public LoginUseCase(AuthenticationManager authenticationManager,
                       JwtService jwtService,
                       AppProperties appProperties,
                       RefreshTokenService refreshTokenService,
-                      AuthResponseFactory authResponseFactory,
-                      SimpleCaptchaValidationService captchaValidationService) {
+                      AuthResponseFactory authResponseFactory) {
     this.authenticationManager = authenticationManager;
     this.jwtService = jwtService;
     this.appProperties = appProperties;
     this.refreshTokenService = refreshTokenService;
     this.authResponseFactory = authResponseFactory;
-    this.captchaValidationService = captchaValidationService;
   }
 
   public AuthResponse handle(AuthRequest request) {
-    captchaValidationService.validate(request.captcha());
     Authentication authentication = authenticationManager.authenticate(
       new UsernamePasswordAuthenticationToken(request.email(), request.password())
     );

--- a/pymerp/backend/src/main/java/com/datakomerz/pymes/auth/dto/AuthRequest.java
+++ b/pymerp/backend/src/main/java/com/datakomerz/pymes/auth/dto/AuthRequest.java
@@ -1,11 +1,7 @@
 package com.datakomerz.pymes.auth.dto;
 
-import com.datakomerz.pymes.common.captcha.SimpleCaptchaPayload;
-import jakarta.validation.Valid;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 
 public record AuthRequest(@NotBlank @Email String email,
-                          @NotBlank String password,
-                          @NotNull @Valid SimpleCaptchaPayload captcha) {}
+                          @NotBlank String password) {}

--- a/pymerp/backend/src/test/java/com/datakomerz/pymes/auth/AuthControllerIT.java
+++ b/pymerp/backend/src/test/java/com/datakomerz/pymes/auth/AuthControllerIT.java
@@ -8,7 +8,6 @@ import com.datakomerz.pymes.company.Company;
 import com.datakomerz.pymes.company.CompanyRepository;
 import com.datakomerz.pymes.products.Product;
 import com.datakomerz.pymes.products.ProductRepository;
-import com.datakomerz.pymes.common.captcha.SimpleCaptchaPayload;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.OffsetDateTime;
@@ -185,24 +184,18 @@ class AuthControllerIT {
   }
 
   @Test
-  void loginFailsWhenCaptchaInvalid() throws Exception {
-    SimpleCaptchaPayload captcha = new SimpleCaptchaPayload(3, 4, "999");
-    AuthRequest request = new AuthRequest(ADMIN_EMAIL, "Secret123!", captcha);
+  void loginFailsWithInvalidCredentials() throws Exception {
+    AuthRequest request = new AuthRequest(ADMIN_EMAIL, "WrongPassword!");
 
     mockMvc.perform(post("/api/v1/auth/login")
         .contentType(MediaType.APPLICATION_JSON)
         .content(objectMapper.writeValueAsString(request))
         .header("X-Company-Id", companyId.toString()))
-      .andExpect(status().isBadRequest())
-      .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
-      .andExpect(jsonPath("$.title").value("Bad Request"))
-      .andExpect(jsonPath("$.field").value("captcha.answer"))
-      .andExpect(jsonPath("$.type").value("https://pymerp.cl/problems/captcha-invalid"));
+      .andExpect(status().isUnauthorized());
   }
 
   private AuthResponse login() throws Exception {
-    SimpleCaptchaPayload captcha = new SimpleCaptchaPayload(2, 3, "5");
-    AuthRequest request = new AuthRequest(ADMIN_EMAIL, "Secret123!", captcha);
+    AuthRequest request = new AuthRequest(ADMIN_EMAIL, "Secret123!");
 
     String loginResponse = mockMvc.perform(post("/api/v1/auth/login")
         .contentType(MediaType.APPLICATION_JSON)

--- a/pymerp/ui/src/services/client.ts
+++ b/pymerp/ui/src/services/client.ts
@@ -1115,7 +1115,6 @@ export type SimpleCaptchaPayload = {
 export type LoginPayload = {
   email: string;
   password: string;
-  captcha: SimpleCaptchaPayload;
 };
 
 export type RefreshPayload = {


### PR DESCRIPTION
## Summary
- remove the captcha field from the login DTO and use case so authentication no longer validates captchas
- update the authentication integration test to cover invalid credentials instead of captcha failures
- simplify the landing login form and associated tests to submit only email and password while keeping the request captcha flow intact

## Testing
- ./gradlew test
- npm run test -- LandingExperience.test.tsx

------
https://chatgpt.com/codex/tasks/task_b_68d775ed52e083309c2e4761bae91e3d