### PR TITLE
feat: expand sales dashboard metrics

### DIFF
--- a/pymerp/ui/src/App.css
+++ b/pymerp/ui/src/App.css
@@ -165,6 +165,24 @@ body {
   gap: 16px;
 }
 
+button.card {
+  border: none;
+  cursor: pointer;
+  text-align: left;
+  font: inherit;
+  color: inherit;
+}
+
+button.card:disabled {
+  cursor: not-allowed;
+  opacity: 0.7;
+}
+
+button.card:focus-visible {
+  outline: 2px solid var(--primary);
+  outline-offset: 4px;
+}
+
 .card.stretch {
   height: 100%;
 }
@@ -1189,6 +1207,14 @@ body {
   align-items: center;
 }
 
+.filter-bar label {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 0.8rem;
+  color: var(--muted);
+}
+
 .filter-bar .input,
 .filter-bar select {
   width: auto;
@@ -1203,4 +1229,31 @@ body {
 .table-actions .btn {
   padding: 6px 12px;
   font-size: 0.8rem;
+}
+
+.documents-modal__sections {
+  display: grid;
+  gap: 16px;
+}
+
+@media (min-width: 720px) {
+  .documents-modal__sections {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.documents-modal__section h4 {
+  margin: 0;
+}
+
+.documents-modal__empty {
+  color: var(--muted);
+  font-style: italic;
+}
+
+.documents-modal__footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+  margin-top: 16px;
 }


### PR DESCRIPTION
## Summary
- add API client types and fallbacks for sales metrics, trend ranges, and grouped documents listings
- refresh the sales page KPIs, add the documents modal, and support filtering the trend chart by date range
- adjust shared styles so metric cards can be buttons and document modals render with responsive layouts

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_b_68d874cca3b483309181dfaa4b218ba0