### PR TITLE
feat: expand documents modal with preview actions

### DIFF
--- a/pymerp/ui/src/App.css
+++ b/pymerp/ui/src/App.css
@@ -1145,6 +1145,11 @@ button.card:focus-visible {
   flex-direction: column;
 }
 
+.modal--wide {
+  width: min(95vw, 1280px);
+  max-height: 92vh;
+}
+
 .modal-header {
   display: flex;
   align-items: center;
@@ -1242,6 +1247,13 @@ button.card:focus-visible {
   }
 }
 
+@media (min-width: 960px) {
+  .documents-modal__sections {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    align-items: start;
+  }
+}
+
 .documents-modal__section h4 {
   margin: 0;
 }
@@ -1256,4 +1268,44 @@ button.card:focus-visible {
   justify-content: flex-end;
   gap: 12px;
   margin-top: 16px;
+}
+
+.documents-modal__preview {
+  border-top: 1px solid var(--border);
+  padding-top: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.documents-modal__preview-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.documents-modal__preview-header h4 {
+  margin: 0;
+}
+
+.documents-modal__preview-meta {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+.documents-modal__preview-frame {
+  width: 100%;
+  min-height: 320px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: var(--surface);
+}
+
+@media (min-width: 960px) {
+  .documents-modal__preview-frame {
+    min-height: 460px;
+  }
 }

--- a/pymerp/ui/src/components/dialogs/Modal.tsx
+++ b/pymerp/ui/src/components/dialogs/Modal.tsx
@@ -6,9 +6,17 @@ interface ModalProps {
   onClose: () => void;
   children: ReactNode;
   initialFocusRef?: RefObject<HTMLElement>;
+  className?: string;
 }
 
-export default function Modal({ open, title, onClose, children, initialFocusRef }: ModalProps) {
+export default function Modal({
+  open,
+  title,
+  onClose,
+  children,
+  initialFocusRef,
+  className,
+}: ModalProps) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const headingId = useId();
 
@@ -64,7 +72,7 @@ export default function Modal({ open, title, onClose, children, initialFocusRef 
   return (
     <div className="modal-backdrop" role="presentation">
       <div
-        className="modal"
+        className={className ? `modal ${className}` : "modal"}
         role="dialog"
         aria-modal="true"
         aria-labelledby={headingId}


### PR DESCRIPTION
## Summary
- widen the documents modal layout and add a preview section with responsive styling
- wire document actions to real API calls for opening, downloading, printing, and previewing records
- expose document file utilities in the client service to support previews and downloads

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d8816f18108330868aac51f2cb53e4