### PR TITLE
Add wide documents modal with live document actions

### DIFF
--- a/pymerp/ui/src/App.css
+++ b/pymerp/ui/src/App.css
@@ -1145,6 +1145,10 @@ button.card:focus-visible {
   flex-direction: column;
 }
 
+.modal--wide {
+  width: min(95vw, 1300px);
+}
+
 .modal-header {
   display: flex;
   align-items: center;
@@ -1158,6 +1162,12 @@ button.card:focus-visible {
   display: flex;
   flex-direction: column;
   gap: 16px;
+}
+
+.documents-modal__content {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
 }
 
 .item-builder {
@@ -1249,6 +1259,58 @@ button.card:focus-visible {
 .documents-modal__empty {
   color: var(--muted);
   font-style: italic;
+}
+
+.documents-modal__preview {
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 16px;
+  background: var(--surface);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.documents-modal__preview header {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.documents-modal__preview header h5 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.documents-modal__preview-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  font-size: 0.9rem;
+}
+
+.documents-modal__preview-meta span {
+  color: var(--muted);
+}
+
+.documents-modal__preview-frame {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  overflow: hidden;
+  min-height: 260px;
+  background: var(--surface-alt);
+}
+
+.documents-modal__preview-frame iframe {
+  width: 100%;
+  height: 100%;
+  border: 0;
+  background: #fff;
+}
+
+.documents-modal__preview-empty {
+  margin: 0;
+  color: var(--muted);
 }
 
 .documents-modal__footer {

--- a/pymerp/ui/src/components/dialogs/Modal.tsx
+++ b/pymerp/ui/src/components/dialogs/Modal.tsx
@@ -1,14 +1,17 @@
 import { ReactNode, RefObject, useEffect, useId, useRef } from "react";
 
+type ModalSize = "default" | "wide";
+
 interface ModalProps {
   open: boolean;
   title: string;
   onClose: () => void;
   children: ReactNode;
   initialFocusRef?: RefObject<HTMLElement>;
+  size?: ModalSize;
 }
 
-export default function Modal({ open, title, onClose, children, initialFocusRef }: ModalProps) {
+export default function Modal({ open, title, onClose, children, initialFocusRef, size = "default" }: ModalProps) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const headingId = useId();
 
@@ -64,7 +67,7 @@ export default function Modal({ open, title, onClose, children, initialFocusRef 
   return (
     <div className="modal-backdrop" role="presentation">
       <div
-        className="modal"
+        className={`modal${size === "wide" ? " modal--wide" : ""}`}
         role="dialog"
         aria-modal="true"
         aria-labelledby={headingId}


### PR DESCRIPTION
## Summary
- widen the documents modal, add preview styling, and keep tables readable at 95% viewport width
- extend the shared modal component with a wide size option and add React Query state to drive document previews/downloads
- call new service helpers that fetch document details, previews, and downloads with offline fallbacks

## Testing
- npm run lint *(fails: script not defined)*

------
https://chatgpt.com/codex/tasks/task_b_68d8816f18108330868aac51f2cb53e4