### PR TITLE
feat: update dashboard panel metrics and trend

### DIFF
--- a/pymerp/ui/src/App.css
+++ b/pymerp/ui/src/App.css
@@ -219,6 +219,132 @@ button.card:focus-visible {
   background: rgba(255, 255, 255, 0.04);
 }
 
+.dashboard-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.panel-filter {
+  gap: 20px;
+}
+
+.panel-filter-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.panel-filter-status {
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.panel-filter-status.busy {
+  color: var(--accent);
+}
+
+.date-filter {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+}
+
+.date-filter label {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 0.88rem;
+}
+
+.date-filter input[type="date"] {
+  background: var(--panel-alt);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 10px 12px;
+  font: inherit;
+}
+
+.panel-kpis {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
+}
+
+.kpi-card {
+  gap: 12px;
+}
+
+.kpi-value {
+  font-size: 1.65rem;
+  font-weight: 600;
+}
+
+.kpi-meta {
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.panel-error {
+  color: var(--error);
+}
+
+.kpi-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.kpi-list li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  background: var(--panel-alt);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 10px 12px;
+}
+
+.kpi-list-label {
+  font-weight: 500;
+}
+
+.kpi-list-value {
+  color: var(--muted);
+  font-size: 0.88rem;
+}
+
+.panel-chart {
+  gap: 16px;
+}
+
+.panel-chart-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.chart-wrapper {
+  height: 320px;
+}
+
+@media (max-width: 768px) {
+  .panel-filter-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .panel-filter-status {
+    align-self: flex-start;
+  }
+}
+
 /* Products */
 .products-card {
   gap: 20px;

--- a/pymerp/ui/src/pages/DashboardPage.tsx
+++ b/pymerp/ui/src/pages/DashboardPage.tsx
@@ -1,152 +1,262 @@
-import { useMemo } from "react";
+import type { ChangeEvent } from "react";
+import { useEffect, useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
+import { useSearchParams } from "react-router-dom";
 import {
-  listCompanies,
-  listInventoryAlerts,
-  listSalesDaily,
-  listProducts,
-  Page,
-  Company,
-  SalesDailyPoint,
-  InventoryAlert,
-  Product,
-} from "../services/client";
-import PageHeader from "../components/layout/PageHeader";
-import HealthCard from "../components/HealthCard";
-import CompaniesCard from "../components/CompaniesCard";
-import CreateCompanyForm from "../components/CreateCompanyForm";
-import ProductsCard from "../components/ProductsCard";
-import SuppliersCard from "../components/SuppliersCard";
-import CustomersCard from "../components/CustomersCard";
-import {
-  AreaChart,
-  Area,
-  ResponsiveContainer,
   CartesianGrid,
+  Legend,
+  Line,
+  LineChart,
+  ResponsiveContainer,
   Tooltip,
   XAxis,
   YAxis,
 } from "recharts";
+import PageHeader from "../components/layout/PageHeader";
+import {
+  type DashboardSalesMetrics,
+  type DashboardSalesMetricsParams,
+  type TrendSeriesResponse,
+  getDashboardSalesMetrics,
+  getPurchaseSaleTrend,
+} from "../services/client";
+
+type DateRange = { from: string; to: string };
+
+const DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
+
+function addDays(base: Date, amount: number): Date {
+  const copy = new Date(base);
+  copy.setDate(copy.getDate() + amount);
+  return copy;
+}
+
+function formatAsInputDate(date: Date): string {
+  const year = date.getFullYear();
+  const month = `${date.getMonth() + 1}`.padStart(2, "0");
+  const day = `${date.getDate()}`.padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+function buildDefaultRange(): DateRange {
+  const today = new Date();
+  const start = addDays(today, -13);
+  return { from: formatAsInputDate(start), to: formatAsInputDate(today) };
+}
+
+function normalizeRange(
+  fromValue: string | null,
+  toValue: string | null,
+  fallback: DateRange,
+): DateRange {
+  const from = DATE_REGEX.test(fromValue ?? "") ? fromValue! : fallback.from;
+  const to = DATE_REGEX.test(toValue ?? "") ? toValue! : fallback.to;
+  if (from > to) {
+    return { from, to: from };
+  }
+  return { from, to };
+}
 
 export default function DashboardPage() {
-  const companiesQuery = useQuery<Company[], Error>({ queryKey: ["companies"], queryFn: listCompanies });
-  const salesMetricsQuery = useQuery<SalesDailyPoint[], Error>({
-    queryKey: ["sales", "dashboard"],
-    queryFn: () => listSalesDaily(14),
+  const [searchParams, setSearchParams] = useSearchParams();
+  const defaultRange = useMemo(buildDefaultRange, []);
+
+  const rawRange = useMemo(
+    () => ({
+      from: searchParams.get("from"),
+      to: searchParams.get("to"),
+    }),
+    [searchParams],
+  );
+
+  const range = useMemo(
+    () => normalizeRange(rawRange.from, rawRange.to, defaultRange),
+    [rawRange.from, rawRange.to, defaultRange],
+  );
+
+  useEffect(() => {
+    if (rawRange.from !== range.from || rawRange.to !== range.to) {
+      setSearchParams({ from: range.from, to: range.to }, { replace: true });
+    }
+  }, [rawRange.from, rawRange.to, range.from, range.to, setSearchParams]);
+
+  const handleRangeChange = (field: "from" | "to") => (event: ChangeEvent<HTMLInputElement>) => {
+    const value = event.target.value;
+    if (!DATE_REGEX.test(value)) {
+      return;
+    }
+    let nextFrom = field === "from" ? value : range.from;
+    let nextTo = field === "to" ? value : range.to;
+    if (nextFrom > nextTo) {
+      if (field === "from") {
+        nextTo = value;
+      } else {
+        nextFrom = value;
+      }
+    }
+    setSearchParams({ from: nextFrom, to: nextTo });
+  };
+
+  const { from, to } = range;
+
+  const metricsQuery = useQuery<DashboardSalesMetrics, Error>({
+    queryKey: ["salesMetrics", from, to],
+    queryFn: () => getDashboardSalesMetrics({ from, to } satisfies DashboardSalesMetricsParams),
+    enabled: Boolean(from && to),
   });
-  const alertsQuery = useQuery<InventoryAlert[], Error>({
-    queryKey: ["inventory", "alerts", { dashboard: true }],
-    queryFn: () => listInventoryAlerts(5),
-  });
-  const productsQuery = useQuery<Page<Product>, Error>({
-    queryKey: ["products", { dashboard: true }],
-    queryFn: () => listProducts({ size: 200 }),
+
+  const trendQuery = useQuery<TrendSeriesResponse, Error>({
+    queryKey: ["trend", from, to, "purchase-sale"],
+    queryFn: () => getPurchaseSaleTrend({ from, to, series: "purchase,sale" }),
+    enabled: Boolean(from && to),
   });
 
-  const salesTotals = useMemo(() => {
-    const data = salesMetricsQuery.data ?? [];
-    const total = data.reduce((acc, point) => acc + Number(point.total), 0);
-    const docs = data.reduce((acc, point) => acc + point.count, 0);
-    const avg = data.length ? total / data.length : 0;
-    return { total, docs, avg };
-  }, [salesMetricsQuery.data]);
+  const currencyFormatter = useMemo(
+    () => new Intl.NumberFormat("es-CL", { style: "currency", currency: "CLP", maximumFractionDigits: 0 }),
+    [],
+  );
 
-  const chartData = useMemo(() => (
-    (salesMetricsQuery.data ?? []).map((point) => ({
-      date: point.date,
-      total: Number(point.total),
-    }))
-  ), [salesMetricsQuery.data]);
+  const formatCurrency = (value: number | null | undefined) => currencyFormatter.format(value ?? 0);
 
-  const inventoryAlerts = alertsQuery.data ?? [];
+  const chartData = useMemo(() => {
+    if (!trendQuery.data) {
+      return [] as Array<{ date: string; purchase: number; sale: number }>;
+    }
+    const points = new Map<string, { date: string; purchase: number; sale: number }>();
+    trendQuery.data.purchase.forEach((point) => {
+      const entry = points.get(point.date) ?? { date: point.date, purchase: 0, sale: 0 };
+      entry.purchase = point.value ?? 0;
+      points.set(point.date, entry);
+    });
+    trendQuery.data.sale.forEach((point) => {
+      const entry = points.get(point.date) ?? { date: point.date, purchase: 0, sale: 0 };
+      entry.sale = point.value ?? 0;
+      points.set(point.date, entry);
+    });
+    return Array.from(points.values()).sort((a, b) => a.date.localeCompare(b.date));
+  }, [trendQuery.data]);
 
-  const kpiData = [
-    { title: "Compañías", value: companiesQuery.data?.length ?? 0, trend: "Entorno multi-tenant" },
-    { title: "Ventas 14d", value: `$${salesTotals.total.toLocaleString()}`, trend: `${salesTotals.docs} documentos` },
-    { title: "Ticket diario", value: `$${salesTotals.avg.toFixed(0)}`, trend: "Promedio 14 días" },
-    { title: "Alertas stock", value: inventoryAlerts.length, trend: "Umbral configurado" },
-  ];
+  const paymentMethods = metricsQuery.data?.topPaymentMethods ?? [];
+  const topMethods = paymentMethods.slice(0, 4);
+  const isUpdating = metricsQuery.isFetching || trendQuery.isFetching;
 
   return (
-    <div className="dashboard">
+    <div className="dashboard-panel">
       <PageHeader
-        title="Resumen ejecutivo"
-        description="Monitorea indicadores clave, salud del sistema y catálogos recientes."
+        title="Panel de control"
+        description="Visualiza tus KPIs diarios y compara la tendencia de compras versus ventas."
       />
 
-      <section className="kpi-grid">
-        {kpiData.map((item) => (
-          <div key={item.title} className="card stat">
-            <h3>{item.title}</h3>
-            <p className="stat-value">{item.value}</p>
-            <span className="stat-trend">{item.trend}</span>
+      <section className="card panel-filter" aria-labelledby="panel-filter-title">
+        <div className="panel-filter-header">
+          <h3 id="panel-filter-title">Filtro por fechas</h3>
+          <span className={`panel-filter-status ${isUpdating ? "busy" : ""}`} role="status">
+            {isUpdating ? "Actualizando datos..." : "Datos al día"}
+          </span>
+        </div>
+        <div className="date-filter" role="group" aria-label="Rango de fechas">
+          <label>
+            <span>Desde</span>
+            <input
+              type="date"
+              value={from}
+              max={to}
+              onChange={handleRangeChange("from")}
+            />
+          </label>
+          <label>
+            <span>Hasta</span>
+            <input
+              type="date"
+              value={to}
+              min={from}
+              onChange={handleRangeChange("to")}
+            />
+          </label>
+        </div>
+        <p className="muted small">Período seleccionado: {from} a {to}</p>
+      </section>
+
+      <section className="panel-kpis" aria-label="Indicadores clave">
+        <article className="card kpi-card">
+          <h3>Ventas del día</h3>
+          {metricsQuery.isLoading ? (
+            <p className="muted">Cargando...</p>
+          ) : metricsQuery.isError ? (
+            <p className="panel-error">No se pudieron cargar los indicadores.</p>
+          ) : (
+            <>
+              <p className="kpi-value">{formatCurrency(metricsQuery.data?.totalDay ?? 0)}</p>
+              <p className="kpi-meta">Total emitido el {to}</p>
+            </>
+          )}
+        </article>
+
+        <article className="card kpi-card">
+          <h3>Producto más vendido</h3>
+          {metricsQuery.isLoading ? (
+            <p className="muted">Cargando...</p>
+          ) : metricsQuery.isError ? (
+            <p className="panel-error">No se pudieron cargar los indicadores.</p>
+          ) : metricsQuery.data?.topProduct ? (
+            <>
+              <p className="kpi-value">{metricsQuery.data.topProduct.name}</p>
+              <p className="kpi-meta">{metricsQuery.data.topProduct.qty} unidades</p>
+            </>
+          ) : (
+            <p className="muted">Sin datos para el período seleccionado.</p>
+          )}
+        </article>
+
+        <article className="card kpi-card">
+          <h3>Formas de pago más utilizadas</h3>
+          {metricsQuery.isLoading ? (
+            <p className="muted">Cargando...</p>
+          ) : metricsQuery.isError ? (
+            <p className="panel-error">No se pudieron cargar los indicadores.</p>
+          ) : topMethods.length > 0 ? (
+            <ul className="kpi-list">
+              {topMethods.map((method) => (
+                <li key={method.method}>
+                  <span className="kpi-list-label">{method.method}</span>
+                  <span className="kpi-list-value">{method.count} usos</span>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="muted">No hay ventas registradas en este rango.</p>
+          )}
+        </article>
+      </section>
+
+      <section className="card panel-chart" aria-labelledby="overview-title">
+        <div className="panel-chart-header">
+          <div>
+            <h3 id="overview-title">Vista general</h3>
+            <p className="muted small">Comparativo de compras vs. ventas</p>
           </div>
-        ))}
-      </section>
-
-      <section className="card">
-        <h3>Tendencia de ventas (14 días)</h3>
-        <div style={{ height: 260 }}>
-          <ResponsiveContainer width="100%" height="100%">
-            <AreaChart data={chartData}>
-              <defs>
-                <linearGradient id="dashboardSales" x1="0" y1="0" x2="0" y2="1">
-                  <stop offset="5%" stopColor="#60a5fa" stopOpacity={0.8}/>
-                  <stop offset="95%" stopColor="#60a5fa" stopOpacity={0}/>
-                </linearGradient>
-              </defs>
-              <CartesianGrid strokeDasharray="3 3" stroke="#1f2937" />
-              <XAxis dataKey="date" stroke="#9aa0a6" tick={{ fontSize: 12 }} />
-              <YAxis stroke="#9aa0a6" tickFormatter={(value) => `$${(value / 1000).toFixed(0)}k`} />
-              <Tooltip formatter={(value: number) => `$${value.toLocaleString()}`}/>
-              <Area type="monotone" dataKey="total" stroke="#60a5fa" fill="url(#dashboardSales)" />
-            </AreaChart>
-          </ResponsiveContainer>
         </div>
-      </section>
-
-      <section className="responsive-grid">
-        <div className="card stretch"><HealthCard /></div>
-        <div className="card"><CompaniesCard /></div>
-        <div className="card"><CreateCompanyForm /></div>
-      </section>
-
-      <section className="responsive-grid large">
-        <div className="card"><ProductsCard /></div>
-        <div className="card"><SuppliersCard /></div>
-        <div className="card"><CustomersCard /></div>
-      </section>
-
-      <section className="card table-card">
-        <h3>Alertas de inventario</h3>
-        <div className="table-wrapper">
-          <table className="table">
-            <thead>
-              <tr>
-                <th>Producto</th>
-                <th>Lote</th>
-                <th>Disponible</th>
-                <th>Registrado</th>
-              </tr>
-            </thead>
-            <tbody>
-              {inventoryAlerts.map((alert) => {
-                const product = productsQuery.data?.content.find((p) => p.id === alert.productId);
-                return (
-                  <tr key={alert.lotId}>
-                    <td>{product?.name ?? alert.productId}</td>
-                    <td className="mono">{alert.lotId}</td>
-                    <td className="mono">{Number(alert.qtyAvailable).toFixed(2)}</td>
-                    <td className="mono small">{new Date(alert.createdAt).toLocaleDateString()}</td>
-                  </tr>
-                );
-              })}
-              {inventoryAlerts.length === 0 && (
-                <tr><td colSpan={4} className="muted">Sin alertas activas</td></tr>
-              )}
-            </tbody>
-          </table>
-        </div>
+        {trendQuery.isLoading ? (
+          <p className="muted">Cargando tendencia...</p>
+        ) : trendQuery.isError ? (
+          <p className="panel-error">No se pudo cargar la tendencia.</p>
+        ) : chartData.length === 0 ? (
+          <p className="muted">Sin datos para el rango seleccionado.</p>
+        ) : (
+          <div className="chart-wrapper">
+            <ResponsiveContainer width="100%" height="100%">
+              <LineChart data={chartData} margin={{ top: 20, right: 24, bottom: 8, left: 0 }}>
+                <CartesianGrid strokeDasharray="3 3" stroke="#1f2937" />
+                <XAxis dataKey="date" stroke="#9aa0a6" tick={{ fontSize: 12 }} />
+                <YAxis stroke="#9aa0a6" tickFormatter={(value) => formatCurrency(Number(value))} width={96} />
+                <Tooltip formatter={(value: number) => formatCurrency(value)} labelFormatter={(label) => `Fecha: ${label}`} />
+                <Legend />
+                <Line type="monotone" dataKey="sale" name="Ventas" stroke="#60a5fa" strokeWidth={2} dot={false} />
+                <Line type="monotone" dataKey="purchase" name="Compras" stroke="#f97316" strokeWidth={2} dot={false} />
+              </LineChart>
+            </ResponsiveContainer>
+          </div>
+        )}
       </section>
     </div>
   );


### PR DESCRIPTION
## Summary
- add a global date filter to the dashboard panel with KPI cards for daily sales, top product, and payment methods
- implement sales metric and purchase vs sale trend services with offline fallbacks
- refresh panel styling and add a comparative line chart in the "Vista general" card

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_b_68d89eb986988330a96ccdf36c7314ca