### PR TITLE
feat(sales): connect dashboard to real sales reports

### DIFF
--- a/pymerp/backend/src/main/java/com/datakomerz/pymes/config/ClockConfig.java
+++ b/pymerp/backend/src/main/java/com/datakomerz/pymes/config/ClockConfig.java
@@ -1,0 +1,14 @@
+package com.datakomerz.pymes.config;
+
+import java.time.Clock;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ClockConfig {
+
+  @Bean
+  public Clock systemClock() {
+    return Clock.systemDefaultZone();
+  }
+}

--- a/pymerp/backend/src/main/java/com/datakomerz/pymes/sales/api/SalesReportController.java
+++ b/pymerp/backend/src/main/java/com/datakomerz/pymes/sales/api/SalesReportController.java
@@ -1,0 +1,46 @@
+package com.datakomerz.pymes.sales.api;
+
+import com.datakomerz.pymes.sales.reports.SalesReportService;
+import com.datakomerz.pymes.sales.reports.SalesSummaryReport;
+import com.datakomerz.pymes.sales.reports.SalesTimeseriesPoint;
+import com.datakomerz.pymes.sales.reports.SalesTimeseriesResponse;
+import java.util.List;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+@RestController
+@RequestMapping("/api/v1/reports/sales")
+public class SalesReportController {
+
+  private final SalesReportService service;
+
+  public SalesReportController(SalesReportService service) {
+    this.service = service;
+  }
+
+  @GetMapping("/summary")
+  public SalesSummaryReport summary(@RequestParam(defaultValue = "14") int days) {
+    if (days <= 0) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "days must be greater than zero");
+    }
+    return service.getSummary(days);
+  }
+
+  @GetMapping("/timeseries")
+  public SalesTimeseriesResponse timeseries(@RequestParam(defaultValue = "14") int days,
+                                            @RequestParam(defaultValue = "day") String bucket) {
+    if (days <= 0) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "days must be greater than zero");
+    }
+    if (!"day".equalsIgnoreCase(bucket)) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Only day bucket is supported");
+    }
+
+    List<SalesTimeseriesPoint> points = service.getDailySeries(days);
+    return new SalesTimeseriesResponse(points);
+  }
+}

--- a/pymerp/backend/src/main/java/com/datakomerz/pymes/sales/reports/SalesReportService.java
+++ b/pymerp/backend/src/main/java/com/datakomerz/pymes/sales/reports/SalesReportService.java
@@ -1,0 +1,110 @@
+package com.datakomerz.pymes.sales.reports;
+
+import com.datakomerz.pymes.core.tenancy.CompanyContext;
+import com.datakomerz.pymes.sales.Sale;
+import com.datakomerz.pymes.sales.SaleRepository;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class SalesReportService {
+
+  private final SaleRepository saleRepository;
+  private final CompanyContext companyContext;
+  private final Clock clock;
+
+  public SalesReportService(SaleRepository saleRepository,
+                            CompanyContext companyContext,
+                            Clock clock) {
+    this.saleRepository = saleRepository;
+    this.companyContext = companyContext;
+    this.clock = clock;
+  }
+
+  public SalesSummaryReport getSummary(int days) {
+    SeriesResult result = buildSeries(days);
+    BigDecimal total = result.total();
+    BigDecimal average = days <= 0
+      ? BigDecimal.ZERO
+      : total.divide(BigDecimal.valueOf(days), 2, RoundingMode.HALF_UP);
+    return new SalesSummaryReport(total, average);
+  }
+
+  public List<SalesTimeseriesPoint> getDailySeries(int days) {
+    return buildSeries(days).points();
+  }
+
+  private SeriesResult buildSeries(int days) {
+    if (days <= 0) {
+      throw new IllegalArgumentException("days must be greater than zero");
+    }
+
+    UUID companyId = companyContext.require();
+    ZoneId zone = clock.getZone();
+    LocalDate end = LocalDate.now(clock);
+    LocalDate start = end.minusDays(days - 1L);
+    OffsetDateTime from = start.atStartOfDay(zone).toOffsetDateTime();
+    OffsetDateTime toExclusive = end.plusDays(1L).atStartOfDay(zone).toOffsetDateTime();
+
+    List<Sale> range = saleRepository
+      .findByCompanyIdAndIssuedAtGreaterThanEqualOrderByIssuedAtAsc(companyId, from);
+
+    Map<LocalDate, BigDecimal> totals = new LinkedHashMap<>();
+    LocalDate cursor = start;
+    while (!cursor.isAfter(end)) {
+      totals.put(cursor, BigDecimal.ZERO);
+      cursor = cursor.plusDays(1);
+    }
+
+    for (Sale sale : range) {
+      if (sale.getIssuedAt() == null) {
+        continue;
+      }
+      if (!sale.getIssuedAt().isBefore(toExclusive)) {
+        continue;
+      }
+      if (isCancelled(sale.getStatus())) {
+        continue;
+      }
+
+      LocalDate day = sale.getIssuedAt().atZoneSameInstant(zone).toLocalDate();
+      if (day.isBefore(start) || day.isAfter(end)) {
+        continue;
+      }
+
+      totals.merge(day, safeAmount(sale.getTotal()), BigDecimal::add);
+    }
+
+    List<SalesTimeseriesPoint> points = new ArrayList<>(totals.size());
+    totals.forEach((date, total) -> points.add(new SalesTimeseriesPoint(date, total)));
+
+    BigDecimal total = points.stream()
+      .map(SalesTimeseriesPoint::total)
+      .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+    return new SeriesResult(points, total);
+  }
+
+  private boolean isCancelled(String status) {
+    return status != null && status.equalsIgnoreCase("cancelled");
+  }
+
+  private BigDecimal safeAmount(BigDecimal value) {
+    return value == null ? BigDecimal.ZERO : value;
+  }
+
+  private record SeriesResult(List<SalesTimeseriesPoint> points, BigDecimal total) {
+  }
+}

--- a/pymerp/backend/src/main/java/com/datakomerz/pymes/sales/reports/SalesSummaryReport.java
+++ b/pymerp/backend/src/main/java/com/datakomerz/pymes/sales/reports/SalesSummaryReport.java
@@ -1,0 +1,6 @@
+package com.datakomerz.pymes.sales.reports;
+
+import java.math.BigDecimal;
+
+public record SalesSummaryReport(BigDecimal total14d, BigDecimal avgDaily14d) {
+}

--- a/pymerp/backend/src/main/java/com/datakomerz/pymes/sales/reports/SalesTimeseriesPoint.java
+++ b/pymerp/backend/src/main/java/com/datakomerz/pymes/sales/reports/SalesTimeseriesPoint.java
@@ -1,0 +1,7 @@
+package com.datakomerz.pymes.sales.reports;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+public record SalesTimeseriesPoint(LocalDate date, BigDecimal total) {
+}

--- a/pymerp/backend/src/main/java/com/datakomerz/pymes/sales/reports/SalesTimeseriesResponse.java
+++ b/pymerp/backend/src/main/java/com/datakomerz/pymes/sales/reports/SalesTimeseriesResponse.java
@@ -1,0 +1,6 @@
+package com.datakomerz.pymes.sales.reports;
+
+import java.util.List;
+
+public record SalesTimeseriesResponse(List<SalesTimeseriesPoint> points) {
+}

--- a/pymerp/backend/src/test/java/com/datakomerz/pymes/sales/SalesReportServiceTest.java
+++ b/pymerp/backend/src/test/java/com/datakomerz/pymes/sales/SalesReportServiceTest.java
@@ -1,0 +1,109 @@
+package com.datakomerz.pymes.sales;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.datakomerz.pymes.core.tenancy.CompanyContext;
+import com.datakomerz.pymes.sales.reports.SalesReportService;
+import com.datakomerz.pymes.sales.reports.SalesSummaryReport;
+import com.datakomerz.pymes.sales.reports.SalesTimeseriesPoint;
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+class SalesReportServiceTest {
+
+  @Autowired
+  private SaleRepository saleRepository;
+
+  private SalesReportService service;
+  private CompanyContext companyContext;
+  private UUID companyId;
+
+  @BeforeEach
+  void setUp() {
+    companyId = UUID.randomUUID();
+    companyContext = Mockito.mock(CompanyContext.class);
+    Mockito.when(companyContext.require()).thenReturn(companyId);
+    Clock clock = Clock.fixed(Instant.parse("2024-05-15T12:00:00Z"), ZoneOffset.UTC);
+    service = new SalesReportService(saleRepository, companyContext, clock);
+  }
+
+  @Test
+  void returnsZerosWhenNoSales() {
+    SalesSummaryReport summary = service.getSummary(14);
+    assertThat(summary.total14d()).isEqualByComparingTo(BigDecimal.ZERO);
+    assertThat(summary.avgDaily14d()).isEqualByComparingTo(BigDecimal.ZERO);
+
+    List<SalesTimeseriesPoint> series = service.getDailySeries(14);
+    assertThat(series).hasSize(14);
+    assertThat(series).allSatisfy(point -> assertThat(point.total()).isEqualByComparingTo(BigDecimal.ZERO));
+    assertThat(series.getFirst().date()).isEqualTo(LocalDate.of(2024, 5, 2));
+    assertThat(series.getLast().date()).isEqualTo(LocalDate.of(2024, 5, 15));
+  }
+
+  @Test
+  void fillsMissingDaysWithZeros() {
+    persistSale(LocalDate.of(2024, 5, 10), new BigDecimal("100"), "emitida", companyId);
+    persistSale(LocalDate.of(2024, 5, 15), new BigDecimal("200"), "emitida", companyId);
+
+    List<SalesTimeseriesPoint> series = service.getDailySeries(14);
+    assertThat(series).hasSize(14);
+
+    SalesTimeseriesPoint tenth = findPoint(series, LocalDate.of(2024, 5, 10));
+    assertThat(tenth.total()).isEqualByComparingTo(new BigDecimal("100"));
+
+    SalesTimeseriesPoint eleventh = findPoint(series, LocalDate.of(2024, 5, 11));
+    assertThat(eleventh.total()).isEqualByComparingTo(BigDecimal.ZERO);
+
+    SalesTimeseriesPoint last = findPoint(series, LocalDate.of(2024, 5, 15));
+    assertThat(last.total()).isEqualByComparingTo(new BigDecimal("200"));
+  }
+
+  @Test
+  void excludesCancelledSalesAndOtherCompanies() {
+    persistSale(LocalDate.of(2024, 5, 12), new BigDecimal("120"), "cancelled", companyId);
+    persistSale(LocalDate.of(2024, 5, 13), new BigDecimal("450"), "emitida", companyId);
+    persistSale(LocalDate.of(2024, 5, 14), new BigDecimal("300"), "emitida", UUID.randomUUID());
+    persistSale(LocalDate.of(2024, 4, 28), new BigDecimal("500"), "emitida", companyId);
+
+    SalesSummaryReport summary = service.getSummary(14);
+    assertThat(summary.total14d()).isEqualByComparingTo(new BigDecimal("450"));
+    assertThat(summary.avgDaily14d()).isEqualByComparingTo(new BigDecimal("32.14"));
+
+    List<SalesTimeseriesPoint> series = service.getDailySeries(14);
+    SalesTimeseriesPoint cancelledDay = findPoint(series, LocalDate.of(2024, 5, 12));
+    assertThat(cancelledDay.total()).isEqualByComparingTo(BigDecimal.ZERO);
+
+    SalesTimeseriesPoint validDay = findPoint(series, LocalDate.of(2024, 5, 13));
+    assertThat(validDay.total()).isEqualByComparingTo(new BigDecimal("450"));
+  }
+
+  private SalesTimeseriesPoint findPoint(List<SalesTimeseriesPoint> series, LocalDate date) {
+    return series.stream()
+      .filter(point -> point.date().equals(date))
+      .findFirst()
+      .orElseThrow(() -> new AssertionError("Point not found for " + date));
+  }
+
+  private void persistSale(LocalDate date, BigDecimal total, String status, UUID owner) {
+    Sale sale = new Sale();
+    sale.setCompanyId(owner);
+    sale.setStatus(status);
+    sale.setNet(total);
+    sale.setVat(BigDecimal.ZERO);
+    sale.setTotal(total);
+    sale.setIssuedAt(OffsetDateTime.of(date.atStartOfDay(), ZoneOffset.UTC));
+    saleRepository.save(sale);
+  }
+}

--- a/pymerp/ui/README.md
+++ b/pymerp/ui/README.md
@@ -1,0 +1,44 @@
+# Ventas - Dashboard conectado a datos reales
+
+El panel de ventas ahora consume los nuevos reportes del backend (`/api/v1/reports/sales/summary` y `/api/v1/reports/sales/timeseries`).
+
+## Cómo validar los datos
+
+1. **Levanta el entorno completo**
+
+   ```bash
+   docker compose up --build
+   ```
+
+   Esto inicia Postgres, Redis, backend y frontend (Vite).
+
+2. **Crea documentos de ventas reales**
+
+   - Usa la UI (`http://localhost:5173`) o envía `POST /api/v1/sales` contra el backend (`http://localhost:8081`).
+   - Asegúrate de incluir ventas en distintos días y con estados mixtos para verificar la exclusión de canceladas.
+
+3. **Verifica los endpoints de reportes**
+
+   - `GET http://localhost:8081/api/v1/reports/sales/summary?days=14`
+   - `GET http://localhost:8081/api/v1/reports/sales/timeseries?days=14&bucket=day`
+
+   Los totales deben coincidir con la suma de las ventas emitidas en los últimos 14 días.
+
+4. **Revisa el dashboard**
+
+   - Ingresa a la página de Ventas en la UI.
+   - Cambia de tenant (selector `X-Company-Id`) si es necesario y confirma que las tarjetas y el gráfico se actualizan.
+   - El gráfico siempre mostrará 14 puntos (uno por día) y los días sin ventas quedarán en cero.
+
+5. **Pruebas unitarias (frontend)**
+
+   ```bash
+   cd ui
+   npm install
+   npm run test -- src/components/sales/__tests__/SalesDashboardOverview.test.tsx
+   ```
+
+## Notas
+
+- El formato de moneda usa CLP por defecto. Si el tenant expone otra moneda, ajusta el `createCurrencyFormatter` en `src/utils/currency.ts`.
+- El backend excluye automáticamente ventas con estado `cancelled` y completa los días sin datos con cero.

--- a/pymerp/ui/src/App.css
+++ b/pymerp/ui/src/App.css
@@ -165,6 +165,68 @@ body {
   gap: 16px;
 }
 
+.card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.dashboard-overview {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.chart-card {
+  position: relative;
+}
+
+.skeleton {
+  position: relative;
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 12px;
+}
+
+.skeleton::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  transform: translateX(-100%);
+  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.18), transparent);
+  animation: skeleton-loading 1.4s infinite;
+}
+
+.skeleton-text {
+  height: 36px;
+}
+
+.skeleton-chart {
+  height: 240px;
+}
+
+@keyframes skeleton-loading {
+  0% {
+    transform: translateX(-100%);
+  }
+  100% {
+    transform: translateX(100%);
+  }
+}
+
+.error-banner {
+  border: 1px solid rgba(248, 113, 113, 0.5);
+  background: rgba(248, 113, 113, 0.12);
+  color: var(--text);
+  padding: 16px;
+  border-radius: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
 button.card {
   border: none;
   cursor: pointer;

--- a/pymerp/ui/src/components/sales/DailyAvgCard.tsx
+++ b/pymerp/ui/src/components/sales/DailyAvgCard.tsx
@@ -1,0 +1,19 @@
+import { formatMoneyCLP } from "../../utils/currency";
+
+type DailyAvgCardProps = {
+  value: number;
+  days?: number;
+  formatter?: (value: number) => string;
+};
+
+export default function DailyAvgCard({ value, days = 14, formatter = formatMoneyCLP }: DailyAvgCardProps) {
+  return (
+    <article className="card stat" aria-label={`Promedio de ventas diarias últimos ${days} días`}>
+      <h3>Promedio venta diaria</h3>
+      <p className="stat-value" data-testid="sales-daily-average">
+        {formatter(value)}
+      </p>
+      <span className="stat-trend">Últimos {days} días</span>
+    </article>
+  );
+}

--- a/pymerp/ui/src/components/sales/SalesDashboardOverview.tsx
+++ b/pymerp/ui/src/components/sales/SalesDashboardOverview.tsx
@@ -1,0 +1,96 @@
+import { useMemo } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import DailyAvgCard from "./DailyAvgCard";
+import Total14DaysCard from "./Total14DaysCard";
+import SalesTrendChart from "./SalesTrendChart";
+import { createCurrencyFormatter } from "../../utils/currency";
+import { useSalesDashboard } from "../../hooks/useSalesDashboard";
+
+type SalesDashboardOverviewProps = {
+  days?: number;
+};
+
+export default function SalesDashboardOverview({ days = 14 }: SalesDashboardOverviewProps) {
+  const queryClient = useQueryClient();
+  const { summary, series, points, computedTotal } = useSalesDashboard(days);
+
+  const currencyFormatter = useMemo(() => createCurrencyFormatter(), []);
+  const formatCurrency = (value: number) => currencyFormatter.format(value ?? 0);
+
+  const totalValue = summary.data?.total14d ?? computedTotal;
+  const averageValue = summary.data?.avgDaily14d ?? (days > 0 ? totalValue / days : 0);
+
+  const isInitialLoading = summary.isLoading && !summary.data && series.isLoading && !series.data;
+  const isRefreshing = (summary.isFetching || series.isFetching) && !isInitialLoading;
+  const hasError = summary.isError || series.isError;
+
+  const handleRetry = () => {
+    queryClient.invalidateQueries({ queryKey: ["sales-summary", days] });
+    queryClient.invalidateQueries({ queryKey: ["sales-series", days] });
+  };
+
+  const chartPoints = series.isSuccess || summary.isSuccess ? points : points;
+
+  return (
+    <section aria-labelledby="sales-dashboard-overview-heading" className="dashboard-overview">
+      <div className="card" style={{ marginBottom: "1.5rem" }}>
+        <header className="card-header">
+          <div>
+            <h2 id="sales-dashboard-overview-heading">Ventas últimas {days} jornadas</h2>
+            <p className="muted">Promedio diario, total acumulado y tendencia por día.</p>
+          </div>
+          {isRefreshing && !hasError && (
+            <span className="muted" role="status">
+              Actualizando…
+            </span>
+          )}
+        </header>
+
+        {hasError && (
+          <div className="error-banner" role="alert">
+            <p>No se pudieron cargar las métricas de ventas de los últimos {days} días.</p>
+            <button className="btn" type="button" onClick={handleRetry}>
+              Reintentar
+            </button>
+          </div>
+        )}
+
+        <div className="kpi-grid" style={{ marginBottom: "1.5rem" }}>
+          {isInitialLoading ? (
+            <SkeletonCard title="Promedio venta diaria" description={`Últimos ${days} días`} />
+          ) : (
+            <DailyAvgCard value={averageValue} days={days} formatter={formatCurrency} />
+          )}
+          {isInitialLoading ? (
+            <SkeletonCard title="Total de ventas" description={`Incluye impuestos · Últimos ${days} días`} />
+          ) : (
+            <Total14DaysCard value={totalValue} days={days} formatter={formatCurrency} />
+          )}
+        </div>
+
+        <div className="chart-card">
+          {isInitialLoading ? (
+            <div className="skeleton skeleton-chart" aria-hidden="true" />
+          ) : (
+            <SalesTrendChart points={chartPoints} formatter={formatCurrency} />
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+type SkeletonCardProps = {
+  title: string;
+  description: string;
+};
+
+function SkeletonCard({ title, description }: SkeletonCardProps) {
+  return (
+    <article className="card stat" aria-busy="true">
+      <h3>{title}</h3>
+      <div className="skeleton skeleton-text" aria-hidden="true" />
+      <span className="stat-trend">{description}</span>
+    </article>
+  );
+}

--- a/pymerp/ui/src/components/sales/SalesTrendChart.tsx
+++ b/pymerp/ui/src/components/sales/SalesTrendChart.tsx
@@ -1,0 +1,68 @@
+import type { CSSProperties } from "react";
+import {
+  Area,
+  AreaChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import { formatMoneyCLP } from "../../utils/currency";
+
+type SalesTrendChartProps = {
+  points: Array<{ date: string; total: number }>;
+  formatter?: (value: number) => string;
+};
+
+const hiddenListStyles: CSSProperties = {
+  position: "absolute",
+  width: 1,
+  height: 1,
+  padding: 0,
+  margin: -1,
+  overflow: "hidden",
+  clip: "rect(0, 0, 0, 0)",
+  whiteSpace: "nowrap",
+  border: 0,
+};
+
+export default function SalesTrendChart({ points, formatter = formatMoneyCLP }: SalesTrendChartProps) {
+  const data = points.map((point) => ({ ...point }));
+  const hasActivity = data.some((point) => point.total > 0);
+
+  return (
+    <div className="chart-container" data-testid="sales-trend-chart" data-point-count={data.length}>
+      <div style={{ height: 260 }} role="img" aria-label="Tendencia de ventas diarias">
+        <ResponsiveContainer width="100%" height="100%">
+          <AreaChart data={data} margin={{ top: 10, right: 24, left: 0, bottom: 0 }}>
+            <defs>
+              <linearGradient id="salesTrendGradient" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="5%" stopColor="#60a5fa" stopOpacity={0.85} />
+                <stop offset="95%" stopColor="#60a5fa" stopOpacity={0} />
+              </linearGradient>
+            </defs>
+            <CartesianGrid strokeDasharray="3 3" stroke="#1f2937" />
+            <XAxis dataKey="date" stroke="#9aa0a6" tick={{ fontSize: 12 }} />
+            <YAxis stroke="#9aa0a6" tickFormatter={(value) => formatter(Number(value))} width={96} />
+            <Tooltip
+              formatter={(value: number) => formatter(value)}
+              labelFormatter={(label) => `Fecha: ${label}`}
+            />
+            <Area type="monotone" dataKey="total" stroke="#60a5fa" fill="url(#salesTrendGradient)" />
+          </AreaChart>
+        </ResponsiveContainer>
+      </div>
+      {!hasActivity && (
+        <p className="muted" role="status">
+          Sin ventas registradas en los últimos días.
+        </p>
+      )}
+      <ul style={hiddenListStyles} data-testid="sales-trend-points">
+        {data.map((point) => (
+          <li key={point.date} data-testid="sales-trend-point">{`${point.date}: ${point.total}`}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/pymerp/ui/src/components/sales/Total14DaysCard.tsx
+++ b/pymerp/ui/src/components/sales/Total14DaysCard.tsx
@@ -1,0 +1,19 @@
+import { formatMoneyCLP } from "../../utils/currency";
+
+type Total14DaysCardProps = {
+  value: number;
+  days?: number;
+  formatter?: (value: number) => string;
+};
+
+export default function Total14DaysCard({ value, days = 14, formatter = formatMoneyCLP }: Total14DaysCardProps) {
+  return (
+    <article className="card stat" aria-label={`Total de ventas últimos ${days} días`}>
+      <h3>Total de ventas</h3>
+      <p className="stat-value" data-testid="sales-total-14d">
+        {formatter(value)}
+      </p>
+      <span className="stat-trend">Incluye impuestos · Últimos {days} días</span>
+    </article>
+  );
+}

--- a/pymerp/ui/src/components/sales/__tests__/SalesDashboardOverview.test.tsx
+++ b/pymerp/ui/src/components/sales/__tests__/SalesDashboardOverview.test.tsx
@@ -1,0 +1,106 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import SalesDashboardOverview from "../SalesDashboardOverview";
+import { fetchSalesSummary, fetchSalesTimeseries } from "../../../services/reports";
+
+vi.mock("../../../services/reports", () => ({
+  fetchSalesSummary: vi.fn(),
+  fetchSalesTimeseries: vi.fn(),
+}));
+
+const mockFetchSalesSummary = fetchSalesSummary as unknown as vi.MockedFunction<typeof fetchSalesSummary>;
+const mockFetchSalesTimeseries = fetchSalesTimeseries as unknown as vi.MockedFunction<typeof fetchSalesTimeseries>;
+
+const currencyFormatter = new Intl.NumberFormat("es-CL", {
+  style: "currency",
+  currency: "CLP",
+  minimumFractionDigits: 0,
+  maximumFractionDigits: 0,
+});
+
+function renderDashboard() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  render(
+    <QueryClientProvider client={queryClient}>
+      <SalesDashboardOverview days={14} />
+    </QueryClientProvider>,
+  );
+}
+
+describe("SalesDashboardOverview", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders zero state when there are no sales", async () => {
+    mockFetchSalesSummary.mockResolvedValue({ total14d: 0, avgDaily14d: 0 });
+    mockFetchSalesTimeseries.mockResolvedValue({ points: [] });
+
+    renderDashboard();
+
+    await waitFor(() => expect(screen.getByTestId("sales-daily-average")).toHaveTextContent("$0"));
+    expect(screen.getByTestId("sales-total-14d")).toHaveTextContent("$0");
+    expect(screen.getAllByTestId("sales-trend-point")).toHaveLength(14);
+    expect(screen.getByText(/Sin ventas registradas en los últimos días/i)).toBeInTheDocument();
+  });
+
+  it("fills missing days with zeros", async () => {
+    const frame = buildFrame(14);
+    mockFetchSalesSummary.mockResolvedValue({ total14d: 300, avgDaily14d: 21.43 });
+    mockFetchSalesTimeseries.mockResolvedValue({
+      points: [
+        { date: frame[5], total: 100 },
+        { date: frame[13], total: 200 },
+      ],
+    });
+
+    renderDashboard();
+
+    await waitFor(() => expect(screen.getByTestId("sales-total-14d")).toHaveTextContent("$300"));
+
+    const pointTexts = screen.getAllByTestId("sales-trend-point").map((item) => item.textContent ?? "");
+    expect(pointTexts).toHaveLength(14);
+    expect(pointTexts.some((text) => text.startsWith(`${frame[6]}: 0`))).toBe(true);
+    expect(pointTexts.some((text) => text.startsWith(`${frame[5]}: 100`))).toBe(true);
+    expect(pointTexts.some((text) => text.startsWith(`${frame[13]}: 200`))).toBe(true);
+  });
+
+  it("displays consecutive daily totals", async () => {
+    const frame = buildFrame(14);
+    const points = frame.map((date, index) => ({ date, total: (index + 1) * 10 }));
+    const total = points.reduce((acc, point) => acc + point.total, 0);
+    const average = total / 14;
+
+    mockFetchSalesSummary.mockResolvedValue({ total14d: total, avgDaily14d: average });
+    mockFetchSalesTimeseries.mockResolvedValue({ points });
+
+    renderDashboard();
+
+    await waitFor(() => expect(screen.getByTestId("sales-total-14d")).toHaveTextContent(currencyFormatter.format(total)));
+    expect(screen.getByTestId("sales-daily-average")).toHaveTextContent(currencyFormatter.format(average));
+    const trendPoints = screen.getAllByTestId("sales-trend-point");
+    expect(trendPoints[0].textContent).toContain(`${frame[0]}: 10`);
+    expect(trendPoints.at(-1)?.textContent).toContain(`${frame[13]}: 140`);
+    expect(screen.queryByText(/Sin ventas registradas en los últimos días/i)).not.toBeInTheDocument();
+  });
+});
+
+function buildFrame(days: number): string[] {
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const dates: string[] = [];
+  for (let i = days - 1; i >= 0; i -= 1) {
+    const current = new Date(today);
+    current.setDate(today.getDate() - i);
+    dates.push(formatLocalDate(current));
+  }
+  return dates;
+}
+
+function formatLocalDate(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}

--- a/pymerp/ui/src/hooks/useSalesDashboard.ts
+++ b/pymerp/ui/src/hooks/useSalesDashboard.ts
@@ -1,0 +1,67 @@
+import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { fetchSalesSummary, fetchSalesTimeseries } from "../services/reports";
+
+export function useSalesDashboard(days = 14) {
+  const summary = useQuery({
+    queryKey: ["sales-summary", days],
+    queryFn: () => fetchSalesSummary(days),
+  });
+
+  const series = useQuery({
+    queryKey: ["sales-series", days],
+    queryFn: () => fetchSalesTimeseries(days),
+  });
+
+  const points = useMemo(() => {
+    const frame = buildFrame(days);
+    const totals = new Map<string, number>();
+    const source = series.data?.points ?? [];
+
+    for (const point of source) {
+      if (!point?.date) {
+        continue;
+      }
+      const normalizedDate = point.date.trim();
+      if (!normalizedDate) {
+        continue;
+      }
+      const current = totals.get(normalizedDate) ?? 0;
+      const value = typeof point.total === "number" && !Number.isNaN(point.total) ? point.total : 0;
+      totals.set(normalizedDate, current + value);
+    }
+
+    return frame.map((date) => ({
+      date,
+      total: totals.get(date) ?? 0,
+    }));
+  }, [series.data, days]);
+
+  const computedTotal = useMemo(
+    () => points.reduce((acc, point) => acc + point.total, 0),
+    [points],
+  );
+
+  return { summary, series, points, computedTotal };
+}
+
+function buildFrame(days: number): string[] {
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const frame: string[] = [];
+
+  for (let i = days - 1; i >= 0; i -= 1) {
+    const current = new Date(today);
+    current.setDate(today.getDate() - i);
+    frame.push(formatLocalDate(current));
+  }
+
+  return frame;
+}
+
+function formatLocalDate(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}

--- a/pymerp/ui/src/services/client.ts
+++ b/pymerp/ui/src/services/client.ts
@@ -2657,6 +2657,8 @@ export function createInventoryAdjustment(payload: InventoryAdjustmentPayload): 
   );
 }
 
+export default api;
+
 
 
 

--- a/pymerp/ui/src/services/reports.ts
+++ b/pymerp/ui/src/services/reports.ts
@@ -1,0 +1,29 @@
+import client from "./client";
+
+export type SalesSummaryResponse = {
+  total14d: number;
+  avgDaily14d: number;
+};
+
+export type SalesTimeseriesPoint = {
+  date: string;
+  total: number;
+};
+
+export type SalesTimeseriesResponse = {
+  points: SalesTimeseriesPoint[];
+};
+
+export async function fetchSalesSummary(days = 14): Promise<SalesSummaryResponse> {
+  const { data } = await client.get<SalesSummaryResponse>("/v1/reports/sales/summary", {
+    params: { days },
+  });
+  return data;
+}
+
+export async function fetchSalesTimeseries(days = 14): Promise<SalesTimeseriesResponse> {
+  const { data } = await client.get<SalesTimeseriesResponse>("/v1/reports/sales/timeseries", {
+    params: { days, bucket: "day" },
+  });
+  return data;
+}

--- a/pymerp/ui/src/utils/currency.ts
+++ b/pymerp/ui/src/utils/currency.ts
@@ -1,0 +1,27 @@
+const DEFAULT_LOCALE = "es-CL";
+const DEFAULT_CURRENCY = "CLP";
+
+const clpFormatter = new Intl.NumberFormat(DEFAULT_LOCALE, {
+  style: "currency",
+  currency: DEFAULT_CURRENCY,
+  minimumFractionDigits: 0,
+  maximumFractionDigits: 0,
+});
+
+export function createCurrencyFormatter(currency?: string): Intl.NumberFormat {
+  const normalized = currency && currency.length === 3 ? currency.toUpperCase() : DEFAULT_CURRENCY;
+  const zeroDecimal = normalized === DEFAULT_CURRENCY;
+  return new Intl.NumberFormat(DEFAULT_LOCALE, {
+    style: "currency",
+    currency: normalized,
+    minimumFractionDigits: zeroDecimal ? 0 : 2,
+    maximumFractionDigits: zeroDecimal ? 0 : 2,
+  });
+}
+
+export function formatMoneyCLP(value: number | null | undefined): string {
+  if (value === null || value === undefined || Number.isNaN(value)) {
+    return clpFormatter.format(0);
+  }
+  return clpFormatter.format(value);
+}


### PR DESCRIPTION
## Summary
- add reporting service and controller that expose 14-day sales summary and timeseries, plus supporting clock bean
- exclude cancelled sales, backfill empty days, and cover edge cases with a dedicated `SalesReportService` test suite
- consume the new endpoints from the sales dashboard with a React Query hook, dedicated cards/chart components, refreshed styling, and documentation for validating the data

## Testing
- ./gradlew test --no-daemon --console=plain
- npm run test -- src/components/sales/__tests__/SalesDashboardOverview.test.tsx

------
https://chatgpt.com/codex/tasks/task_b_68d8b69348bc8330a1d0efe9d9c1fceb