### PR TITLE
Refactor sales overview and add chart date filter

### DIFF
--- a/pymerp/ui/src/components/sales/DailyAvgCard.tsx
+++ b/pymerp/ui/src/components/sales/DailyAvgCard.tsx
@@ -8,12 +8,12 @@ type DailyAvgCardProps = {
 
 export default function DailyAvgCard({ value, days = 14, formatter = formatMoneyCLP }: DailyAvgCardProps) {
   return (
-    <article className="card stat" aria-label={`Promedio de ventas diarias últimos ${days} días`}>
-      <h3>Promedio venta diaria</h3>
+    <article className="card stat" aria-label={`Promedio diario de ventas considerando ${days} días`}>
+      <h3>Promedio diario</h3>
       <p className="stat-value" data-testid="sales-daily-average">
         {formatter(value)}
       </p>
-      <span className="stat-trend">Últimos {days} días</span>
+      <span className="stat-trend">Periodo analizado: {days} días</span>
     </article>
   );
 }

--- a/pymerp/ui/src/components/sales/SalesDashboardOverview.tsx
+++ b/pymerp/ui/src/components/sales/SalesDashboardOverview.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import DailyAvgCard from "./DailyAvgCard";
 import Total14DaysCard from "./Total14DaysCard";
@@ -14,41 +14,106 @@ export default function SalesDashboardOverview({ days = 14 }: SalesDashboardOver
   const queryClient = useQueryClient();
   const { summary, series, points, computedTotal } = useSalesDashboard(days);
 
+  const [chartRange, setChartRange] = useState<{ start: string; end: string } | null>(null);
+
   const currencyFormatter = useMemo(() => createCurrencyFormatter(), []);
   const formatCurrency = (value: number) => currencyFormatter.format(value ?? 0);
 
   const totalValue = summary.data?.total14d ?? computedTotal;
   const averageValue = summary.data?.avgDaily14d ?? (days > 0 ? totalValue / days : 0);
 
-  const isInitialLoading = summary.isLoading && !summary.data && series.isLoading && !series.data;
-  const isRefreshing = (summary.isFetching || series.isFetching) && !isInitialLoading;
-  const hasError = summary.isError || series.isError;
+  const summaryInitialLoading = summary.isLoading && !summary.data;
+  const seriesInitialLoading = series.isLoading && !series.data;
+  const summaryRefreshing = summary.isFetching && !summaryInitialLoading;
+  const seriesRefreshing = series.isFetching && !seriesInitialLoading;
+
+  const summaryHasError = summary.isError;
+  const seriesHasError = series.isError;
 
   const handleRetry = () => {
     queryClient.invalidateQueries({ queryKey: ["sales-summary", days] });
     queryClient.invalidateQueries({ queryKey: ["sales-series", days] });
   };
 
-  const chartPoints = series.isSuccess || summary.isSuccess ? points : points;
+  const minDate = points[0]?.date ?? "";
+  const maxDate = points.length > 0 ? points[points.length - 1]?.date ?? "" : "";
+
+  useEffect(() => {
+    if (!minDate || !maxDate) {
+      setChartRange(null);
+      return;
+    }
+
+    setChartRange((prev) => {
+      if (!prev) {
+        return { start: minDate, end: maxDate };
+      }
+
+      const normalizedStart = prev.start < minDate ? minDate : prev.start;
+      const normalizedEnd = prev.end > maxDate ? maxDate : prev.end;
+
+      if (normalizedStart > normalizedEnd) {
+        return { start: minDate, end: maxDate };
+      }
+
+      if (normalizedStart !== prev.start || normalizedEnd !== prev.end) {
+        return { start: normalizedStart, end: normalizedEnd };
+      }
+
+      return prev;
+    });
+  }, [minDate, maxDate]);
+
+  const filteredChartPoints = useMemo(() => {
+    if (!chartRange) {
+      return points;
+    }
+
+    const { start, end } = chartRange;
+    if (!start || !end) {
+      return points;
+    }
+
+    return points.filter((point) => point.date >= start && point.date <= end);
+  }, [chartRange, points]);
+
+  const handleStartChange = (value: string) => {
+    if (!value) {
+      return;
+    }
+    setChartRange((prev) => {
+      const safeEnd = prev?.end && prev.end >= value ? prev.end : value;
+      return { start: value, end: safeEnd ?? value };
+    });
+  };
+
+  const handleEndChange = (value: string) => {
+    if (!value) {
+      return;
+    }
+    setChartRange((prev) => {
+      const safeStart = prev?.start && prev.start <= value ? prev.start : value;
+      return { start: safeStart ?? value, end: value };
+    });
+  };
 
   return (
     <section aria-labelledby="sales-dashboard-overview-heading" className="dashboard-overview">
       <div className="card" style={{ marginBottom: "1.5rem" }}>
         <header className="card-header">
           <div>
-            <h2 id="sales-dashboard-overview-heading">Ventas últimas {days} jornadas</h2>
-            <p className="muted">Promedio diario, total acumulado y tendencia por día.</p>
+            <h2 id="sales-dashboard-overview-heading">Resumen de ventas</h2>
           </div>
-          {isRefreshing && !hasError && (
+          {summaryRefreshing && !summaryHasError && (
             <span className="muted" role="status">
               Actualizando…
             </span>
           )}
         </header>
 
-        {hasError && (
+        {summaryHasError && (
           <div className="error-banner" role="alert">
-            <p>No se pudieron cargar las métricas de ventas de los últimos {days} días.</p>
+            <p>No se pudieron cargar los indicadores de ventas.</p>
             <button className="btn" type="button" onClick={handleRetry}>
               Reintentar
             </button>
@@ -56,23 +121,75 @@ export default function SalesDashboardOverview({ days = 14 }: SalesDashboardOver
         )}
 
         <div className="kpi-grid" style={{ marginBottom: "1.5rem" }}>
-          {isInitialLoading ? (
-            <SkeletonCard title="Promedio venta diaria" description={`Últimos ${days} días`} />
+          {summaryInitialLoading ? (
+            <SkeletonCard title="Promedio diario" description={`Periodo analizado: ${days} días`} />
           ) : (
             <DailyAvgCard value={averageValue} days={days} formatter={formatCurrency} />
           )}
-          {isInitialLoading ? (
-            <SkeletonCard title="Total de ventas" description={`Incluye impuestos · Últimos ${days} días`} />
+          {summaryInitialLoading ? (
+            <SkeletonCard title="Ventas acumuladas" description="Montos brutos del periodo" />
           ) : (
             <Total14DaysCard value={totalValue} days={days} formatter={formatCurrency} />
           )}
         </div>
+      </div>
+
+      <div className="card">
+        <header className="card-header" style={{ gap: "1rem", flexWrap: "wrap" }}>
+          <div style={{ display: "flex", flexDirection: "column", gap: "0.25rem" }}>
+            <h2>Tendencia de ventas</h2>
+            {seriesRefreshing && !seriesHasError && (
+              <span className="muted" role="status">
+                Actualizando…
+              </span>
+            )}
+          </div>
+          <div className="field-group" style={{ display: "flex", gap: "0.75rem", alignItems: "center" }}>
+            <label className="field" style={{ display: "flex", flexDirection: "column", gap: "0.25rem" }}>
+              <span className="muted small">Desde</span>
+              <input
+                className="input"
+                type="date"
+                value={chartRange?.start ?? minDate}
+                min={minDate}
+                max={chartRange?.end ?? maxDate}
+                onChange={(event) => handleStartChange(event.target.value)}
+                disabled={seriesInitialLoading || seriesHasError || !minDate}
+              />
+            </label>
+            <label className="field" style={{ display: "flex", flexDirection: "column", gap: "0.25rem" }}>
+              <span className="muted small">Hasta</span>
+              <input
+                className="input"
+                type="date"
+                value={chartRange?.end ?? maxDate}
+                min={chartRange?.start ?? minDate}
+                max={maxDate}
+                onChange={(event) => handleEndChange(event.target.value)}
+                disabled={seriesInitialLoading || seriesHasError || !maxDate}
+              />
+            </label>
+          </div>
+        </header>
+
+        {seriesHasError && (
+          <div className="error-banner" role="alert">
+            <p>No se pudo cargar la tendencia de ventas.</p>
+            <button className="btn" type="button" onClick={handleRetry}>
+              Reintentar
+            </button>
+          </div>
+        )}
 
         <div className="chart-card">
-          {isInitialLoading ? (
+          {seriesInitialLoading ? (
             <div className="skeleton skeleton-chart" aria-hidden="true" />
+          ) : filteredChartPoints.length > 0 ? (
+            <SalesTrendChart points={filteredChartPoints} formatter={formatCurrency} />
           ) : (
-            <SalesTrendChart points={chartPoints} formatter={formatCurrency} />
+            <p className="muted" role="status">
+              No hay ventas registradas en el rango seleccionado.
+            </p>
           )}
         </div>
       </div>

--- a/pymerp/ui/src/components/sales/Total14DaysCard.tsx
+++ b/pymerp/ui/src/components/sales/Total14DaysCard.tsx
@@ -8,12 +8,12 @@ type Total14DaysCardProps = {
 
 export default function Total14DaysCard({ value, days = 14, formatter = formatMoneyCLP }: Total14DaysCardProps) {
   return (
-    <article className="card stat" aria-label={`Total de ventas últimos ${days} días`}>
-      <h3>Total de ventas</h3>
+    <article className="card stat" aria-label={`Ventas acumuladas durante ${days} días`}>
+      <h3>Ventas acumuladas</h3>
       <p className="stat-value" data-testid="sales-total-14d">
         {formatter(value)}
       </p>
-      <span className="stat-trend">Incluye impuestos · Últimos {days} días</span>
+      <span className="stat-trend">Montos brutos del periodo</span>
     </article>
   );
 }

--- a/pymerp/ui/src/components/sales/__tests__/SalesDashboardOverview.test.tsx
+++ b/pymerp/ui/src/components/sales/__tests__/SalesDashboardOverview.test.tsx
@@ -39,10 +39,16 @@ describe("SalesDashboardOverview", () => {
 
     renderDashboard();
 
+    expect(await screen.findByRole("heading", { name: /Resumen de ventas/i })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /Tendencia de ventas/i })).toBeInTheDocument();
+
     await waitFor(() => expect(screen.getByTestId("sales-daily-average")).toHaveTextContent("$0"));
     expect(screen.getByTestId("sales-total-14d")).toHaveTextContent("$0");
     expect(screen.getAllByTestId("sales-trend-point")).toHaveLength(14);
     expect(screen.getByText(/Sin ventas registradas en los últimos días/i)).toBeInTheDocument();
+
+    expect(screen.getByLabelText(/Desde/i)).toHaveAttribute("type", "date");
+    expect(screen.getByLabelText(/Hasta/i)).toHaveAttribute("type", "date");
   });
 
   it("fills missing days with zeros", async () => {


### PR DESCRIPTION
## Summary
- separate the sales overview metrics from the trend chart and rename the chart section to "Tendencia de ventas"
- add a date range filter for the sales trend chart and update status messaging for loading and errors
- refresh KPI labels to remove outdated copy

## Testing
- npm test -- SalesDashboardOverview

------
https://chatgpt.com/codex/tasks/task_b_68d8c669da4083309bc17db00de76c6d