### PR TITLE
Fix sales dashboard component regressions

### DIFF
--- a/pymerp/ui/src/components/sales/DailyAvgCard.tsx
+++ b/pymerp/ui/src/components/sales/DailyAvgCard.tsx
@@ -8,20 +8,12 @@ type DailyAvgCardProps = {
 
 export default function DailyAvgCard({ value, rangeLabel, formatter = formatMoneyCLP }: DailyAvgCardProps) {
   return (
-
     <article className="card stat" aria-label={`Promedio diario de ventas para ${rangeLabel}`}>
-
-    <article className="card stat" aria-label={`Promedio diario de ventas considerando ${days} días`}>
-
       <h3>Promedio diario</h3>
       <p className="stat-value" data-testid="sales-daily-average">
         {formatter(value)}
       </p>
-
       <span className="stat-trend">Rango seleccionado: {rangeLabel}</span>
-
-      <span className="stat-trend">Periodo analizado: {days} días</span>
-
     </article>
   );
 }

--- a/pymerp/ui/src/components/sales/SalesDashboardOverview.tsx
+++ b/pymerp/ui/src/components/sales/SalesDashboardOverview.tsx
@@ -10,27 +10,19 @@ type SalesDashboardOverviewProps = {
   days?: number;
 };
 
+type ChartRange = { start: string; end: string } | null;
+
 export default function SalesDashboardOverview({ days = 14 }: SalesDashboardOverviewProps) {
   const queryClient = useQueryClient();
   const { series, points } = useSalesDashboard(days);
 
-  const [chartRange, setChartRange] = useState<{ start: string; end: string } | null>(null);
-
-  const [chartRange, setChartRange] = useState<{ start: string; end: string } | null>(null);
+  const [chartRange, setChartRange] = useState<ChartRange>(null);
 
   const currencyFormatter = useMemo(() => createCurrencyFormatter(), []);
   const formatCurrency = (value: number) => currencyFormatter.format(value ?? 0);
 
   const seriesInitialLoading = series.isLoading && !series.data;
   const seriesRefreshing = series.isFetching && !seriesInitialLoading;
-
-  const summaryInitialLoading = summary.isLoading && !summary.data;
-  const seriesInitialLoading = series.isLoading && !series.data;
-  const summaryRefreshing = summary.isFetching && !summaryInitialLoading;
-  const seriesRefreshing = series.isFetching && !seriesInitialLoading;
-
-  const summaryHasError = summary.isError;
-
   const seriesHasError = series.isError;
 
   const handleRetry = () => {
@@ -79,7 +71,6 @@ export default function SalesDashboardOverview({ days = 14 }: SalesDashboardOver
     return points.filter((point) => point.date >= start && point.date <= end);
   }, [chartRange, points]);
 
-
   const filteredTotal = useMemo(
     () => filteredChartPoints.reduce((acc, point) => acc + point.total, 0),
     [filteredChartPoints],
@@ -90,13 +81,12 @@ export default function SalesDashboardOverview({ days = 14 }: SalesDashboardOver
       return 0;
     }
     return filteredTotal / filteredChartPoints.length;
-  }, [filteredTotal, filteredChartPoints.length]);
+  }, [filteredChartPoints, filteredTotal]);
 
   const rangeStart = chartRange?.start ?? minDate;
   const rangeEnd = chartRange?.end ?? maxDate;
 
   const rangeLabel = rangeStart && rangeEnd ? formatRange(rangeStart, rangeEnd) : "Sin rango";
-
 
   const handleStartChange = (value: string) => {
     if (!value) {
@@ -127,9 +117,6 @@ export default function SalesDashboardOverview({ days = 14 }: SalesDashboardOver
           </div>
 
           {seriesRefreshing && !seriesHasError && (
-
-          {summaryRefreshing && !summaryHasError && (
-
             <span className="muted" role="status">
               Actualizando…
             </span>
@@ -137,9 +124,6 @@ export default function SalesDashboardOverview({ days = 14 }: SalesDashboardOver
         </header>
 
         {seriesHasError && (
-
-        {summaryHasError && (
-
           <div className="error-banner" role="alert">
             <p>No se pudieron cargar los indicadores de ventas.</p>
             <button className="btn" type="button" onClick={handleRetry}>
@@ -149,33 +133,16 @@ export default function SalesDashboardOverview({ days = 14 }: SalesDashboardOver
         )}
 
         <div className="kpi-grid" style={{ marginBottom: "1.5rem" }}>
-
           {seriesInitialLoading || seriesHasError ? (
             <SkeletonCard title="Promedio diario" description={`Rango seleccionado: ${rangeLabel}`} />
-
-          {summaryInitialLoading ? (
-            <SkeletonCard title="Promedio diario" description={`Periodo analizado: ${days} días`} />
-
           ) : (
-            <DailyAvgCard
-              value={filteredAverage}
-              rangeLabel={rangeLabel}
-              formatter={formatCurrency}
-            />
+            <DailyAvgCard value={filteredAverage} rangeLabel={rangeLabel} formatter={formatCurrency} />
           )}
 
           {seriesInitialLoading || seriesHasError ? (
             <SkeletonCard title="Ventas acumuladas" description={`Rango seleccionado: ${rangeLabel}`} />
-
-          {summaryInitialLoading ? (
-            <SkeletonCard title="Ventas acumuladas" description="Montos brutos del periodo" />
-
           ) : (
-            <Total14DaysCard
-              value={filteredTotal}
-              rangeLabel={rangeLabel}
-              formatter={formatCurrency}
-            />
+            <Total14DaysCard value={filteredTotal} rangeLabel={rangeLabel} formatter={formatCurrency} />
           )}
         </div>
       </div>

--- a/pymerp/ui/src/components/sales/Total14DaysCard.tsx
+++ b/pymerp/ui/src/components/sales/Total14DaysCard.tsx
@@ -12,20 +12,13 @@ export default function Total14DaysCard({
   formatter = formatMoneyCLP,
 }: Total14DaysCardProps) {
   return (
-
     <article className="card stat" aria-label={`Ventas acumuladas para ${rangeLabel}`}>
-
-    <article className="card stat" aria-label={`Ventas acumuladas durante ${days} días`}>
-
       <h3>Ventas acumuladas</h3>
       <p className="stat-value" data-testid="sales-total-14d">
         {formatter(value)}
       </p>
-
       <span className="stat-trend">Rango seleccionado: {rangeLabel}</span>
-
       <span className="stat-trend">Montos brutos del periodo</span>
-
     </article>
   );
 }


### PR DESCRIPTION
## Summary
- simplify the sales dashboard overview component by removing duplicated state and error branches
- normalize the sales metric cards to render a single accessible article with formatter output

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d8cff9e10c833096409291e10ce34d