### PR TITLE
feat: add frequent product recommendations to sale creation

### DIFF
--- a/pymerp/ui/README.md
+++ b/pymerp/ui/README.md
@@ -42,3 +42,11 @@ El panel de ventas ahora consume los nuevos reportes del backend (`/api/v1/repor
 
 - El formato de moneda usa CLP por defecto. Si el tenant expone otra moneda, ajusta el `createCurrencyFormatter` en `src/utils/currency.ts`.
 - El backend excluye automáticamente ventas con estado `cancelled` y completa los días sin datos con cero.
+
+## Registrar venta: productos frecuentes del cliente
+
+- En la pantalla **Registrar venta** activa la casilla **Productos frecuentes del cliente** para ver un panel con los artículos más comprados por el cliente seleccionado.
+- El panel aparece habilitado solo cuando existe un cliente elegido. Cambiar de cliente limpia el filtro y recarga los datos.
+- Puedes filtrar rápidamente por nombre o SKU desde la barra de búsqueda. Cada fila muestra SKU, fecha de la última compra, veces compradas, cantidad promedio y el precio usado en la última venta.
+- Haz clic (o presiona Enter/Espacio) sobre un producto para agregarlo de inmediato a la venta con la última cantidad conocida y el precio vigente.
+- Si el cliente no tiene historial se mostrará un mensaje de estado. En caso de error puedes reintentar desde el botón dentro del panel.

--- a/pymerp/ui/src/App.css
+++ b/pymerp/ui/src/App.css
@@ -1759,3 +1759,159 @@ button.card:focus-visible {
   flex-wrap: wrap;
   gap: 12px;
 }
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+.frequent-products-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.frequent-products-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.frequent-products-toggle input {
+  width: 20px;
+  height: 20px;
+}
+
+.frequent-products-toggle input:disabled + span {
+  color: var(--muted);
+}
+
+.frequent-products-panel {
+  gap: 12px;
+}
+
+.frequent-products-header {
+  flex-wrap: wrap;
+}
+
+.frequent-products-heading {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.frequent-products-search {
+  max-width: 280px;
+  width: 100%;
+}
+
+.frequent-products-content {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.frequent-products-loading {
+  display: grid;
+  gap: 8px;
+}
+
+.frequent-products-error {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+  background: rgba(248, 113, 113, 0.12);
+  border: 1px solid rgba(248, 113, 113, 0.45);
+  padding: 12px;
+  border-radius: 12px;
+}
+
+.frequent-products-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.frequent-product-row {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 12px;
+  background: var(--panel-alt);
+  transition: border-color 0.2s ease, transform 0.2s ease;
+}
+
+.frequent-product-row:hover,
+.frequent-product-row:focus-visible {
+  border-color: var(--accent);
+  transform: translateY(-1px);
+  outline: none;
+}
+
+.frequent-product-row:active {
+  transform: translateY(0);
+}
+
+.frequent-product-main {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.frequent-product-name {
+  font-weight: 600;
+}
+
+.frequent-product-sku {
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.frequent-product-meta {
+  display: grid;
+  gap: 8px;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  margin: 0;
+}
+
+.frequent-product-meta div {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.frequent-product-meta dt {
+  font-size: 0.75rem;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.frequent-product-meta dd {
+  margin: 0;
+  font-weight: 600;
+}
+
+@media (max-width: 768px) {
+  .frequent-products-search {
+    max-width: none;
+  }
+
+  .frequent-product-meta {
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  }
+}

--- a/pymerp/ui/src/components/sales/FrequentProductsPanel.tsx
+++ b/pymerp/ui/src/components/sales/FrequentProductsPanel.tsx
@@ -1,0 +1,187 @@
+import { useEffect, useMemo, useState } from "react";
+import { useFrequentProducts } from "../../hooks/useFrequentProducts";
+import type { FrequentProduct } from "../../services/client";
+
+const currencyFormatter = new Intl.NumberFormat("es-CL", {
+  style: "currency",
+  currency: "CLP",
+  minimumFractionDigits: 0,
+  maximumFractionDigits: 0,
+});
+
+function formatDate(value: string) {
+  try {
+    return new Date(value).toLocaleDateString();
+  } catch (error) {
+    return value;
+  }
+}
+
+type FrequentProductsPanelProps = {
+  customerId?: string;
+  visible: boolean;
+  onPick: (product: FrequentProduct, meta?: { lastQty?: number }) => void;
+};
+
+export function FrequentProductsPanel({ customerId, visible, onPick }: FrequentProductsPanelProps) {
+  const [query, setQuery] = useState("");
+  const {
+    data,
+    isLoading,
+    isFetching,
+    isError,
+    refetch,
+  } = useFrequentProducts(customerId);
+
+  useEffect(() => {
+    setQuery("");
+  }, [customerId]);
+
+  const filtered = useMemo(() => {
+    if (!data) {
+      return [];
+    }
+    const normalized = query.trim().toLowerCase();
+    if (!normalized) {
+      return data;
+    }
+    return data.filter((item) => {
+      const name = item.name?.toLowerCase() ?? "";
+      const sku = item.sku?.toLowerCase() ?? "";
+      return name.includes(normalized) || sku.includes(normalized);
+    });
+  }, [data, query]);
+
+  if (!visible || !customerId) {
+    return null;
+  }
+
+  const showSearch = (data?.length ?? 0) > 0;
+  const loading = isLoading || (isFetching && !(data && data.length));
+
+  return (
+    <section className="card frequent-products-panel" aria-label="Productos frecuentes del cliente" aria-live="polite">
+      <header className="card-header frequent-products-header">
+        <div className="frequent-products-heading">
+          <h2 className="card-title">Productos frecuentes</h2>
+          <p className="muted">Basado en compras anteriores del cliente.</p>
+        </div>
+        {showSearch ? (
+          <div className="frequent-products-search">
+            <label className="sr-only" htmlFor="frequent-products-search">
+              Buscar producto frecuente
+            </label>
+            <input
+              id="frequent-products-search"
+              type="search"
+              className="input"
+              placeholder="Buscar por nombre o SKU"
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              autoComplete="off"
+            />
+          </div>
+        ) : null}
+      </header>
+
+      <div className="frequent-products-content" aria-busy={loading}>
+        {loading ? (
+          <div className="frequent-products-loading" role="status" aria-live="polite">
+            <div className="skeleton skeleton-text" aria-hidden="true" />
+            <div className="skeleton skeleton-text" aria-hidden="true" />
+            <div className="skeleton skeleton-text" aria-hidden="true" />
+          </div>
+        ) : null}
+
+        {!loading && isError ? (
+          <div className="frequent-products-error" role="alert">
+            <p>No pudimos cargar los productos frecuentes.</p>
+            <button type="button" className="btn" onClick={() => refetch()}>
+              Reintentar
+            </button>
+          </div>
+        ) : null}
+
+        {!loading && !isError && (data?.length ?? 0) === 0 ? (
+          <p className="muted" role="status">
+            Este cliente no tiene compras previas.
+          </p>
+        ) : null}
+
+        {!loading && !isError && filtered.length > 0 ? (
+          <ul className="frequent-products-list">
+            {filtered.map((item) => {
+              const lastDateLabel = formatDate(item.lastPurchasedAt);
+              const averageLabel =
+                item.avgQty !== undefined && item.avgQty !== null
+                  ? Number(item.avgQty).toFixed(1)
+                  : null;
+              const priceLabel =
+                item.lastUnitPrice !== undefined && item.lastUnitPrice !== null
+                  ? currencyFormatter.format(item.lastUnitPrice)
+                  : null;
+              const handleActivate = () => onPick(item, { lastQty: item.lastQty });
+
+              return (
+                <li key={item.productId}>
+                  <div
+                    role="button"
+                    tabIndex={0}
+                    className="frequent-product-row"
+                    onClick={handleActivate}
+                    onKeyDown={(event) => {
+                      if (event.key === "Enter" || event.key === " ") {
+                        event.preventDefault();
+                        handleActivate();
+                      }
+                    }}
+                    aria-label={`Agregar ${item.name}`}
+                  >
+                    <div className="frequent-product-main">
+                      <span className="frequent-product-name">{item.name}</span>
+                      <span className="frequent-product-sku">SKU: {item.sku || "—"}</span>
+                    </div>
+                    <dl className="frequent-product-meta">
+                      <div>
+                        <dt>Última compra</dt>
+                        <dd>{lastDateLabel}</dd>
+                      </div>
+                      <div>
+                        <dt>Veces compradas</dt>
+                        <dd>{item.totalPurchases}</dd>
+                      </div>
+                      {item.lastQty !== undefined ? (
+                        <div>
+                          <dt>Última cantidad</dt>
+                          <dd>{item.lastQty}</dd>
+                        </div>
+                      ) : null}
+                      {averageLabel ? (
+                        <div>
+                          <dt>Cantidad promedio</dt>
+                          <dd>{averageLabel}</dd>
+                        </div>
+                      ) : null}
+                      {priceLabel ? (
+                        <div>
+                          <dt>Último precio</dt>
+                          <dd>{priceLabel}</dd>
+                        </div>
+                      ) : null}
+                    </dl>
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        ) : null}
+
+        {!loading && !isError && filtered.length === 0 && (data?.length ?? 0) > 0 ? (
+          <p className="muted" role="status">
+            No encontramos coincidencias para "{query}".
+          </p>
+        ) : null}
+      </div>
+    </section>
+  );
+}

--- a/pymerp/ui/src/hooks/__tests__/useFrequentProducts.test.tsx
+++ b/pymerp/ui/src/hooks/__tests__/useFrequentProducts.test.tsx
@@ -1,0 +1,76 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { type ReactNode } from "react";
+import { afterEach, describe, expect, it, vi, type Mock } from "vitest";
+import { useFrequentProducts } from "../useFrequentProducts";
+import { getFrequentProducts, type FrequentProduct } from "../../services/client";
+
+vi.mock("../../services/client", async () => {
+  const actual = await vi.importActual<typeof import("../../services/client")>("../../services/client");
+  return {
+    ...actual,
+    getFrequentProducts: vi.fn(),
+  };
+});
+
+const mockedGetFrequentProducts = getFrequentProducts as unknown as Mock;
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+describe("useFrequentProducts", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("obtiene los productos frecuentes del cliente", async () => {
+    const sample: FrequentProduct[] = [
+      {
+        productId: "prd-1",
+        name: "Café",
+        sku: "SKU-1",
+        lastPurchasedAt: new Date().toISOString(),
+        totalPurchases: 3,
+        avgQty: 4,
+        lastUnitPrice: 1290,
+        lastQty: 5,
+      },
+    ];
+
+    mockedGetFrequentProducts.mockResolvedValueOnce(sample);
+
+    const wrapper = createWrapper();
+    const { result } = renderHook(() => useFrequentProducts("cus-1"), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(sample);
+    expect(mockedGetFrequentProducts).toHaveBeenCalledWith("cus-1");
+  });
+
+  it("no ejecuta la consulta cuando no hay cliente", async () => {
+    const wrapper = createWrapper();
+    const { result } = renderHook(() => useFrequentProducts(undefined), { wrapper });
+
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.isFetched).toBe(false);
+    expect(mockedGetFrequentProducts).not.toHaveBeenCalled();
+  });
+
+  it("propaga los errores de la API", async () => {
+    const error = new Error("Network error");
+    mockedGetFrequentProducts.mockRejectedValueOnce(error);
+
+    const wrapper = createWrapper();
+    const { result } = renderHook(() => useFrequentProducts("cus-2"), { wrapper });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error).toBe(error);
+  });
+});

--- a/pymerp/ui/src/hooks/useFrequentProducts.ts
+++ b/pymerp/ui/src/hooks/useFrequentProducts.ts
@@ -1,0 +1,17 @@
+import { useQuery } from "@tanstack/react-query";
+import { getFrequentProducts, type FrequentProduct } from "../services/client";
+
+export function useFrequentProducts(customerId?: string) {
+  return useQuery<FrequentProduct[]>({
+    queryKey: ["frequent-products", customerId],
+    queryFn: () => {
+      if (!customerId) {
+        throw new Error("customerId is required");
+      }
+      return getFrequentProducts(customerId);
+    },
+    enabled: Boolean(customerId),
+    staleTime: 5 * 60 * 1000,
+    gcTime: 10 * 60 * 1000,
+  });
+}


### PR DESCRIPTION
## Summary
- add a React Query hook and API client support to retrieve frequent products per customer
- surface an accessible frequent products toggle and panel in the sale creation modal with filtering and quick add support
- document the workflow in the sales README and cover the data hook with unit tests

## Testing
- npm run test -- src/hooks/__tests__/useFrequentProducts.test.tsx

------
https://chatgpt.com/codex/tasks/task_b_68daaa0b446c83308f156bb94b277e69