### PR TITLE
feat(ui): defer sale documents fetch to modal

### DIFF
--- a/pymerp/ui/README.md
+++ b/pymerp/ui/README.md
@@ -42,6 +42,7 @@ El panel de ventas ahora consume los nuevos reportes del backend (`/api/v1/repor
 
 - El formato de moneda usa CLP por defecto. Si el tenant expone otra moneda, ajusta el `createCurrencyFormatter` en `src/utils/currency.ts`.
 - El backend excluye automáticamente ventas con estado `cancelled` y completa los días sin datos con cero.
+- La tarjeta "Número de documentos" ya no muestra una previsualización; al hacer clic abre el modal que carga la lista completa de documentos de venta.
 
 ## Registrar venta: productos frecuentes del cliente
 

--- a/pymerp/ui/src/App.css
+++ b/pymerp/ui/src/App.css
@@ -719,6 +719,28 @@ button.card:focus-visible {
   gap: 12px;
 }
 
+.documents-card--action {
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 20px;
+}
+
+.documents-card--action .documents-card__header {
+  width: 100%;
+}
+
+.documents-card__action-hint {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 600;
+}
+
+.documents-card__action-hint::after {
+  content: "→";
+  font-size: 1rem;
+}
+
 .documents-card__header {
   display: flex;
   justify-content: space-between;

--- a/pymerp/ui/src/pages/SalesPage.tsx
+++ b/pymerp/ui/src/pages/SalesPage.tsx
@@ -25,7 +25,6 @@ import useDebouncedValue from "../hooks/useDebouncedValue";
 import { SALE_DOCUMENT_TYPES, SALE_PAYMENT_METHODS } from "../constants/sales";
 import SalesDashboardOverview from "../components/sales/SalesDashboardOverview";
 import SaleDocumentsModal from "../components/sales/SaleDocumentsModal";
-import DocumentsSummaryCard from "../components/documents/DocumentsSummaryCard";
 
 const PAGE_SIZE = 10;
 const TREND_DEFAULT_DAYS = 14;
@@ -189,7 +188,7 @@ export default function SalesPage() {
   const [receiptDocument, setReceiptDocument] = useState<DocumentSummary | null>(null);
   const [receiptError, setReceiptError] = useState<string | null>(null);
   const [saleDocumentsModalOpen, setSaleDocumentsModalOpen] = useState(false);
-  const documentsTriggerRef = useRef<HTMLAnchorElement | null>(null);
+  const documentsTriggerRef = useRef<HTMLButtonElement | null>(null);
   const receiptPrimaryActionRef = useRef<HTMLButtonElement | null>(null);
   const receiptCloseButtonRef = useRef<HTMLButtonElement | null>(null);
 
@@ -603,16 +602,33 @@ export default function SalesPage() {
               : `${formatNumber(salesMonth?.count)} documentos`}
           </span>
         </div>
-        <DocumentsSummaryCard
-          title="Número de documentos"
-          type="SALE"
-          viewAllTo="/app/sales?type=SALE"
-          emptyMessage="No hay documentos de ventas."
-          onViewAllClick={() => {
-            handleOpenDocumentsModal();
-          }}
-          viewAllRef={documentsTriggerRef}
-        />
+        <button
+          type="button"
+          className="card documents-card documents-card--action"
+          onClick={handleOpenDocumentsModal}
+          ref={documentsTriggerRef}
+          aria-describedby="sales-documents-card-description"
+        >
+          <header className="documents-card__header">
+            <div>
+              <h3>Número de documentos</h3>
+              <p className="documents-card__total">
+                {salesQuery.isLoading
+                  ? "Cargando..."
+                  : salesQuery.isError
+                  ? "—"
+                  : (salesQuery.data?.totalElements ?? 0).toLocaleString("es-CL")}
+              </p>
+              <span className="muted small">
+                {salesQuery.isError ? "No se pudo obtener el total actual." : "Total documentos"}
+              </span>
+            </div>
+          </header>
+          <span className="documents-card__action-hint">Ver documentos</span>
+          <span id="sales-documents-card-description" className="muted small">
+            Abre la lista completa en una ventana emergente.
+          </span>
+        </button>
       </section>
 
       <div className="card table-card">


### PR DESCRIPTION
## Summary
- remove the inline sales documents preview card in favor of a full-card trigger that opens the modal
- keep the modal-focused data loading so the sale documents query only runs after opening the dialog
- document the change in the sales README

## Testing
- npm run lint *(fails: script not found)*

------
https://chatgpt.com/codex/tasks/task_b_68db100648148330af0cf598af275f42